### PR TITLE
Include jammy as part of the supported systems in os.query

### DIFF
--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -45,6 +45,11 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
+        ubuntu-22.04-64)
+            os.query is-jammy
+            os.query is-classic
+            ! os.query is-core
+            ;;
         debian-10-64)
             os.query is-debian
             os.query is-debian-10

--- a/tools/os.query
+++ b/tools/os.query
@@ -55,6 +55,10 @@ is_impish() {
     grep -qFx 'UBUNTU_CODENAME=impish' /etc/os-release
 }
 
+is_jammy() {
+    grep -qFx 'UBUNTU_CODENAME=jammy' /etc/os-release
+}
+
 is_ubuntu() {
     grep -qFx 'ID=ubuntu' /etc/os-release || grep -qFx 'ID=ubuntu-core' /etc/os-release
 }


### PR DESCRIPTION
Support ubuntu-22.04-64 on os.query tool

In the future, once the pagination issue is fixed on spread, the new system will be included in spread.yaml