### PR TITLE
Force testing shellchek with versions 0.8 and 0.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,14 @@ jobs:
 
     - name: Run shellCheck for tools
       run: |
+          # Run shellCheck 0.8
           sudo apt-get remove --purge shellcheck
           sudo snap install shellcheck
+          find tools -type f -exec sh -c "head -n 1 {} | egrep -a 'bin/bash|bin/sh' >/dev/null" \; -print -exec shellcheck {} \;
 
+          # Run shellCheck 0.7
+          sudo snap remove shellcheck
+          sudo apt-get install -y shellcheck
           find tools -type f -exec sh -c "head -n 1 {} | egrep -a 'bin/bash|bin/sh' >/dev/null" \; -print -exec shellcheck {} \;
 
   test:


### PR DESCRIPTION
The idea is to shellcheck the tools using versions 0.7 and 0.8