### PR TITLE
New support for s390x arch in os.query tool

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,12 +16,12 @@ jobs:
 
     - name: Run shellCheck for tools
       run: |
-          # Run shellCheck 0.8
+          # Run shellcheck from the snap which most likely is newer than what the distro provides
           sudo apt-get remove --purge shellcheck
           sudo snap install shellcheck
           find tools utils -type f -exec sh -c "head -n 1 {} | egrep -a 'bin/bash|bin/sh' >/dev/null" \; -print -exec shellcheck {} \;
 
-          # Run shellCheck 0.7
+          # Run shellcheck from the distro
           sudo snap remove shellcheck
           sudo apt-get install -y shellcheck
           find tools utils -type f -exec sh -c "head -n 1 {} | egrep -a 'bin/bash|bin/sh' >/dev/null" \; -print -exec shellcheck {} \;

--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -9,6 +9,7 @@ execute: |
             os.query is-trusty
             os.query is-classic
             ! os.query is-core
+            ! os.query is-s390x
             ;;
         ubuntu-16.04-64)
             os.query is-xenial

--- a/tools/os.query
+++ b/tools/os.query
@@ -6,7 +6,7 @@ show_help() {
     echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-impish"
     echo "       os.query is-ubuntu, is-debian, is-fedora, is-amazon-linux, is-arch-linux, is-centos, is-centos-7, is-centos-8, is-opensuse"
     echo "       os.query is-opensuse-tumbleweed, is-debian-sid, is-debian-11, is-debian-10"
-    echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64"
+    echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64, is-s390x"
     echo ""
     echo "Get general information about the current system"
 }
@@ -129,6 +129,10 @@ is_armhf() {
 
 is_arm64() {
     uname -m | grep -Eq '(aarch64.*|armv8.*)'
+}
+
+is_s390x() {
+    uname -m | grep -qFx 's390x'
 }
 
 


### PR DESCRIPTION
Also a minor check is included in the test. It is used trusty because we don't have trusty vms in s390x