### PR TITLE
new tools to get os paths, snap names and cleanup the snaps

### DIFF
--- a/tests/os.paths/task.yaml
+++ b/tests/os.paths/task.yaml
@@ -10,10 +10,15 @@ execute: |
             test "$(os.paths media-dir)" = "/media"
             test "$(os.paths libexec-dir)" = "/usr/lib"
             ;;
-        fedora-*|amazon-*|centos-*|arch-*)
+        fedora-*|amazon-*|centos-*)
             test "$(os.paths snap-mount-dir)" = "/var/lib/snapd/snap"
             test "$(os.paths media-dir)" = "/run/media"
             test "$(os.paths libexec-dir)" = "/usr/libexec"
+            ;;
+        arch-*)
+            test "$(os.paths snap-mount-dir)" = "/var/lib/snapd/snap"
+            test "$(os.paths media-dir)" = "/run/media"
+            test "$(os.paths libexec-dir)" = "/usr/lib"
             ;;
         opensuse-tumbleweed-*)
             test "$(os.paths snap-mount-dir)" = "/snap"

--- a/tests/os.paths/task.yaml
+++ b/tests/os.paths/task.yaml
@@ -1,0 +1,34 @@
+summary: smoke test for the os.paths tool
+
+execute: |
+    os.paths --help | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'
+    os.paths -h | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'
+
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*|debian-*)
+            test "$(os.paths snap-mount-dir)" = "/snap"
+            test "$(os.paths media-dir)" = "/media"
+            test "$(os.paths libexec-dir)" = "/usr/lib"
+            ;;
+        fedora-*|amazon-*|centos-*|arch-*)
+            test "$(os.paths snap-mount-dir)" = "/var/lib/snapd/snap"
+            test "$(os.paths media-dir)" = "/run/media"
+            test "$(os.paths libexec-dir)" = "/usr/libexec"
+            ;;
+        opensuse-tumbleweed-*)
+            test "$(os.paths snap-mount-dir)" = "/snap"
+            test "$(os.paths media-dir)" = "/run/media"
+            test "$(os.paths libexec-dir)" = "/usr/libexec"
+            ;;
+        opensuse-*)
+            test "$(os.paths snap-mount-dir)" = "/snap"
+            test "$(os.paths media-dir)" = "/run/media"
+            test "$(os.paths libexec-dir)" = "/usr/lib"
+            ;;
+        *)
+            echo "System $SPREAD_SYSTEM not supported" 
+            exit 1
+            ;;
+    esac
+
+    os.paths my-dir 2>&1 | MATCH "os.paths: unknown path my-dir"

--- a/tests/snaps.cleanup/task.yaml
+++ b/tests/snaps.cleanup/task.yaml
@@ -1,0 +1,65 @@
+summary: smoke test for the snaps.cleanup tool
+
+execute: |
+    snaps.cleanup --help | MATCH 'usage: snaps.cleanup [--skip <SNAP_NAME>]'
+    snaps.cleanup -h | MATCH 'usage: snaps.cleanup [--skip <SNAP_NAME>]'
+
+    # Start with a clean list of snaps
+    snap wait system seed.loaded
+    for i in $(seq 30); do
+        if snap changes | MATCH ".*Doing.*Auto-refresh.*"; then
+            sleep 1
+        else
+            break
+        fi        
+    done
+    snaps.cleanup
+
+    # Check core is not cleaned
+    if ! snap list core; then
+        snap install core
+    fi
+    if ! snap list snapd; then
+        snap install snapd
+    fi
+    test "$(snap list | wc -l)" = "3"
+    snaps.cleanup
+    test "$(snap list | wc -l)" = "3"
+
+    # Check the snaps and the new base are cleaned
+    snap install test-snapd-tools test-snapd-tools-core18
+    test "$(snap list | wc -l)" = "6"
+    snaps.cleanup
+    test "$(snap list | wc -l)" = "3"
+    snap list core &>/dev/null
+    snap list snapd &>/dev/null
+
+    # Check we can skip a base
+    snap install test-snapd-tools test-snapd-tools-core18
+    snaps.cleanup --skip core18
+    test "$(snap list | wc -l)" = "4"
+    snap list core &>/dev/null
+    snap list core18 &>/dev/null
+    snaps.cleanup
+    test "$(snap list | wc -l)" = "3"
+
+    # Check we can skip a snap and its base
+    snap install test-snapd-tools test-snapd-tools-core18 test-snapd-tools-core20
+    test "$(snap list | wc -l)" = "8"
+    snaps.cleanup --skip test-snapd-tools-core18
+    test "$(snap list | wc -l)" = "5"
+    snap list core &>/dev/null
+    snap list core18 &>/dev/null
+    snap list test-snapd-tools-core18 &>/dev/null
+    snaps.cleanup
+    test "$(snap list | wc -l)" = "3"
+
+    # Check we can skip all the snaps
+    snap install test-snapd-tools test-snapd-tools-core18 test-snapd-tools-core20
+    test "$(snap list | wc -l)" = "8"
+    snaps.cleanup --skip test-snapd-tools --skip test-snapd-tools-core18 --skip test-snapd-tools-core20
+    test "$(snap list | wc -l)" = "8"
+    snaps.cleanup
+    test "$(snap list | wc -l)" = "3"
+
+    snaps.cleanup skip core 2>&1 | MATCH "snaps.cleanup: unknown subcommand skip"

--- a/tests/snaps.cleanup/task.yaml
+++ b/tests/snaps.cleanup/task.yaml
@@ -1,12 +1,14 @@
 summary: smoke test for the snaps.cleanup tool
 
+systems: [ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
+
 execute: |
     snaps.cleanup --help | MATCH 'usage: snaps.cleanup [--skip <SNAP_NAME>]'
     snaps.cleanup -h | MATCH 'usage: snaps.cleanup [--skip <SNAP_NAME>]'
 
     # Start with a clean list of snaps
     snap wait system seed.loaded
-    for i in $(seq 30); do
+    for _ in $(seq 30); do
         if snap changes | MATCH ".*Doing.*Auto-refresh.*"; then
             sleep 1
         else

--- a/tests/snaps.cleanup/task.yaml
+++ b/tests/snaps.cleanup/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the snaps.cleanup tool
 
-systems: [ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
     snaps.cleanup --help | MATCH 'usage: snaps.cleanup [--skip <SNAP_NAME>]'

--- a/tests/snaps.name/task.yaml
+++ b/tests/snaps.name/task.yaml
@@ -1,0 +1,11 @@
+summary: smoke test for the snaps.name tool
+
+execute: |
+    snaps.name --help | MATCH 'usage: snaps.name gadget, kernel, core'
+    snaps.name -h | MATCH 'usage: snaps.name gadget, kernel, core'
+
+    test -z "$(snaps.name gadget)"
+    test -z "$(snaps.name kernel)"
+    test "$(snaps.name core)" = "core"
+
+    snaps.name my-snap 2>&1 | MATCH "snaps.name: unknown snap my-snap"

--- a/tools/os.paths
+++ b/tools/os.paths
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+show_help() {
+    echo "usage: os.paths snap-mount-dir, media-dir, libexec-dir"
+    echo ""
+    echo "get paths information for the current system"
+}
+
+snap_mount_dir() {
+    local SNAP_MOUNT_DIR=/snap
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|arch-*)
+            SNAP_MOUNT_DIR=/var/lib/snapd/snap
+            ;;
+        *)
+            ;;
+    esac
+    echo "$SNAP_MOUNT_DIR"
+}
+
+media_dir() {
+    local MEDIA_DIR=/media
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|arch-*|opensuse-*)
+            MEDIA_DIR=/run/media
+            ;;
+        *)
+            ;;
+    esac
+    echo "$MEDIA_DIR"
+}
+
+libexec_dir() {
+    local LIBEXEC_DIR=/usr/lib
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|amazon-*|centos-*|opensuse-tumbleweed-*)
+            LIBEXEC_DIR=/usr/libexec
+            ;;
+        *)
+            ;;
+    esac
+    echo "$LIBEXEC_DIR"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    local subcommand="$1"
+    local action=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                action=$(echo "$subcommand" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "os.paths: unknown path $subcommand" >&2
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tools/snaps.cleanup
+++ b/tools/snaps.cleanup
@@ -25,7 +25,7 @@ cleanup() {
                 ;;
             *)
                 # Check if a snap should be kept, there's a list of those in spread.yaml.
-                keep=0
+                local keep=0
                 for skip_snap in $skip_snaps; do
                     if [ "$snap" = "$skip_snap" ]; then
                         # Skip the snap base removal as well

--- a/tools/snaps.cleanup
+++ b/tools/snaps.cleanup
@@ -1,0 +1,94 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: snaps.cleanup [--skip <SNAP_NAME>]"
+    echo
+    echo "cleanup the snaps installed in the current system"
+}
+
+cleanup() {
+    skip_snaps=$@
+
+    snap_mount_dir="$(os.paths snap-mount-dir)"
+    remove_bases=""
+    skip_bases=""
+
+    gadget_name="$(snaps.name gadget)"
+    kernel_name="$(snaps.name kernel)"
+    core_name="$(snaps.name core)"
+
+    # remove all app snaps first
+    for snap in "$snap_mount_dir"/*; do
+        snap="${snap:6}"
+        case "$snap" in
+            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | "snapd" |README)
+                ;;
+            *)
+                # Check if a snap should be kept, there's a list of those in spread.yaml.
+                keep=0
+                for skip_snap in $skip_snaps; do
+                    if [ "$snap" = "$skip_snap" ]; then
+                        # Skip the snap base removal as well
+                        snap_base=$(grep "base:" "$snap_mount_dir/$snap/current/meta/snap.yaml" | awk '{ print $2 }')
+                        if [ -n "$snap_base" ]; then
+                            skip_bases="$skip_bases $snap_base"
+                        fi
+                        keep=1
+                        break
+                    fi
+                done
+                if [ "$keep" -eq 0 ]; then
+                    if snap info --verbose "$snap" | grep -E '^type: +(base|core)'; then
+                        if [ -z "$remove_bases" ]; then
+                            remove_bases="$snap"
+                        else
+                            remove_bases="$remove_bases $snap"
+                        fi
+                    else
+                        snap remove --purge "$snap"
+                    fi
+                fi
+                ;;
+        esac
+    done
+    # remove all base/os snaps at the end
+    # skip the base snaps for the 
+    if [ -n "$remove_bases" ]; then
+        for base in $remove_bases; do
+            if ! [[ $skip_bases =~ (^|[[:space:]])$base($|[[:space:]]) ]]; then
+                snap remove --purge "$base"
+                if [ -d "$snap_mount_dir/$base" ]; then
+                    echo "Error: removing base $base has unexpected leftover dir $snap_mount_dir/$base"
+                    ls -al "$snap_mount_dir"
+                    ls -al "$snap_mount_dir/$base"
+                    exit 1
+                fi
+            fi
+        done
+    fi
+}
+
+main() {
+    local skip
+    skip=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            --skip)
+                skip="$skip $2"
+                shift 2
+                ;;
+            *)
+                echo "snaps.cleanup: unknown subcommand $1" >&2
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+    cleanup "$skip"
+}
+
+main "$@"

--- a/tools/snaps.name
+++ b/tools/snaps.name
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+show_help() {
+    echo "usage: snaps.name gadget, kernel, core"
+    echo ""
+    echo "Get the name of a specific snap for the current system"
+}
+
+gadget_name() {
+    echo "$(snap list | grep 'gadget$' | awk '{ print $1 }')"
+}
+
+kernel_name(){
+    echo "$(snap list | grep 'kernel$' | awk '{ print $1 }')"
+}
+
+core_name(){
+    core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
+    if [ -z "$core_name" ]; then
+        core_name="core"
+    fi
+    echo "$core_name"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    local subcommand="$1"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            gadget)
+                gadget_name
+                exit
+                ;;
+            kernel)
+                kernel_name
+                exit
+                ;;
+            core)
+                core_name
+                exit
+                ;;
+            *)
+                echo "snaps.name: unknown snap $1" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+}
+
+main "$@"

--- a/tools/snaps.name
+++ b/tools/snaps.name
@@ -3,7 +3,7 @@
 show_help() {
     echo "usage: snaps.name gadget, kernel, core"
     echo ""
-    echo "Get the name of a specific snap for the current system"
+    echo "get the name of a specific snap for the current system"
 }
 
 gadget_name() {
@@ -15,6 +15,7 @@ kernel_name(){
 }
 
 core_name(){
+    local core_name
     core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
     if [ -z "$core_name" ]; then
         core_name="core"


### PR DESCRIPTION
The change include 3 new tools and their tests

The tools are:
os.paths: get paths information for the current system
snaps.name: get the name of a specific snap for the current system
snaps.cleanup: cleanup the snaps installed in the current system