### PR TITLE
os.query tool cli simplified and new systems supported

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -18,17 +18,18 @@ backends:
             - ubuntu-21.10-64:
             - ubuntu-22.04-64:
             - debian-10-64:
+            - debian-11-64:
             - debian-sid-64:            
-            - fedora-34-64:
             - fedora-35-64:
+            - fedora-36-64:
             - arch-linux-64:
             - amazon-linux-2-64:
-                storage: preserve-size
             - centos-7-64:
-                storage: preserve-size
             - centos-8-64:
-                storage: preserve-size
             - opensuse-15.3-64:
+            - opensuse-15.4-64:
+            - opensuse-tumbleweed-64:
+
 
 path: /root/snapd-testing-tools
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -24,6 +24,7 @@ backends:
             - fedora-36-64:
             - arch-linux-64:
             - amazon-linux-2-64:
+                storage: preserve-size
             - centos-7-64:
                 storage: preserve-size
             - centos-8-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -25,7 +25,9 @@ backends:
             - arch-linux-64:
             - amazon-linux-2-64:
             - centos-7-64:
+                storage: preserve-size
             - centos-8-64:
+                storage: preserve-size
             - centos-9-64:
                 storage: preserve-size
             - opensuse-15.3-64:

--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -32,7 +32,7 @@ execute: |
             os.query is-bionic
             os.query is-classic
             os.query is-ubuntu 18.04
-            c
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
             os.query is-pc-amd64
             ;;

--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -8,28 +8,39 @@ execute: |
         ubuntu-14.04-64)
             os.query is-trusty
             os.query is-classic
+            os.query is-ubuntu 14.04
+            ! os.query is-ubuntu 18.04
             ! os.query is-core
             ! os.query is-s390x
             ;;
         ubuntu-16.04-64)
             os.query is-xenial
             os.query is-classic
+            os.query is-ubuntu 16.04
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
             ;;
         ubuntu-18.04-32)
             os.query is-bionic
             os.query is-classic
+            os.query is-ubuntu 18.04
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
             os.query is-pc-i386
             ;;       
         ubuntu-18.04-64)
             os.query is-bionic
             os.query is-classic
+            os.query is-ubuntu 18.04
+            c
             ! os.query is-core
+            os.query is-pc-amd64
             ;;
         ubuntu-20.04-64)
             os.query is-focal
             os.query is-ubuntu
+            os.query is-ubuntu 20.04
+            ! os.query is-ubuntu 21.04
             ! os.query is-debian
             os.query is-classic
             ! os.query is-core
@@ -37,34 +48,47 @@ execute: |
             ! os.query is-arm
             ;;
         ubuntu-21.10-64)
-            os.query is-impish
             os.query is-classic
+            os.query is-ubuntu 21.10
+            ! os.query is-ubuntu 21.04
             ! os.query is-core
             ;;
         ubuntu-22.04-64)
             os.query is-jammy
             os.query is-classic
+            os.query is-ubuntu 22.04
+            ! os.query is-ubuntu 20.04
             ! os.query is-core
             ;;
         debian-10-64)
             os.query is-debian
-            os.query is-debian-10
+            os.query is-debian 10
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        debian-11-64)
+            os.query is-debian
+            os.query is-debian 11
             os.query is-classic
             ! os.query is-core
             ;;
         debian-sid-64)
             os.query is-debian
-            os.query is-debian-sid
-            os.query is-classic
-            ! os.query is-core
-            ;;
-        fedora-34-64)
-            os.query is-fedora
+            os.query is-debian sid
             os.query is-classic
             ! os.query is-core
             ;;
         fedora-35-64)
             os.query is-fedora
+            os.query is-fedora 35
+            ! os.query is-fedora rawhide
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        fedora-36-64)
+            os.query is-fedora
+            os.query is-fedora 36
+            ! os.query is-fedora rawhide
             os.query is-classic
             ! os.query is-core
             ;;
@@ -78,19 +102,35 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
-        centos-7-64)
-            os.query is-centos-7
+        centos-7-64)            
             os.query is-centos
+            os.query is-centos 7
             os.query is-classic
             ! os.query is-core
             ;;
-        centos-8-64)
-            os.query is-centos-8
+        centos-8-64)            
             os.query is-centos
+            os.query is-centos 8
             ! os.query is-core
             ;;
+        centos-9-64)            
+            os.query is-centos 9
         opensuse-15.3-64)
             os.query is-opensuse
+            os.query is-opensuse 15.3
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        opensuse-15.4-64)
+            os.query is-opensuse
+            os.query is-opensuse 15.4
+            ! os.query is-opensuse tumbleweed
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        opensuse-tumbleweed-64)
+            os.query is-opensuse
+            os.query is-opensuse tumbleweed
             os.query is-classic
             ! os.query is-core
             ;;

--- a/tools/os.query
+++ b/tools/os.query
@@ -90,15 +90,12 @@ is_amazon_linux() {
 }
 
 is_centos() {
-    grep -qFx 'ID="centos"' /etc/os-release
     VERSION=$1
     if [ -z "$VERSION" ]; then
         grep -qFx 'ID="centos"' /etc/os-release
     else
         grep -qFx 'ID="centos"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
     fi
-is_centos_9() {
-    grep -qFx 'ID="centos"' /etc/os-release && grep -qFx 'VERSION_ID="9"' /etc/os-release
 }
 
 is_arch_linux() {

--- a/tools/os.query
+++ b/tools/os.query
@@ -81,7 +81,7 @@ is_fedora() {
     elif [ "$VERSION" == "rawhide" ]; then
         [[ "$SPREAD_SYSTEM" == fedora-rawhide-* ]]
     else
-        grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+        grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "VERSION_ID=$VERSION" /etc/os-release
     fi
 }
 
@@ -109,7 +109,7 @@ is_opensuse() {
     elif [ "$VERSION" == "tumbleweed" ]; then
         grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
     else
-        grep -qFx 'ID="centos"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+        grep -qFx 'ID="opensuse-leap"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
     fi
 }
 

--- a/tools/os.query
+++ b/tools/os.query
@@ -3,9 +3,8 @@
 show_help() {
     echo "usage: os.query is-core, is-classic"
     echo "       os.query is-core16, is-core18, is-core20, is-core22"
-    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-impish, is-jammy"
-    echo "       os.query is-ubuntu, is-debian, is-fedora, is-amazon-linux, is-arch-linux, is-centos, is-centos-7, is-centos-8, is-opensuse"
-    echo "       os.query is-opensuse-tumbleweed, is-debian-sid, is-debian-11, is-debian-10"
+    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy"
+    echo "       os.query is-ubuntu [ID], is-debian [ID], is-fedora [ID], is-amazon-linux, is-arch-linux, is-centos [ID], is-opensuse [ID]"
     echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64, is-s390x"
     echo ""
     echo "Get general information about the current system"
@@ -51,36 +50,39 @@ is_focal() {
     grep -qFx 'UBUNTU_CODENAME=focal' /etc/os-release
 }
 
-is_impish() {
-    grep -qFx 'UBUNTU_CODENAME=impish' /etc/os-release
-}
-
 is_jammy() {
     grep -qFx 'UBUNTU_CODENAME=jammy' /etc/os-release
 }
 
 is_ubuntu() {
-    grep -qFx 'ID=ubuntu' /etc/os-release || grep -qFx 'ID=ubuntu-core' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=ubuntu' /etc/os-release || grep -qFx 'ID=ubuntu-core' /etc/os-release
+    else
+        grep -qFx 'ID=ubuntu' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_debian() {
-    grep -qFx 'ID=debian' /etc/os-release
-}
-
-is_debian_10() {
-    grep -qFx 'ID=debian' /etc/os-release && grep -qFx 'VERSION_ID="10"' /etc/os-release
-}
-
-is_debian_11() {
-    grep -qFx 'ID=debian' /etc/os-release && grep -qFx 'VERSION_ID="11"' /etc/os-release
-}
-
-is_debian_sid() {
-    [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=debian' /etc/os-release
+    elif [ "$VERSION" == "sid" ]; then
+        [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+    else
+        grep -qFx 'ID=debian' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_fedora() {
-    grep -qFx 'ID=fedora' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=fedora' /etc/os-release
+    elif [ "$VERSION" == "rawhide" ]; then
+        [[ "$SPREAD_SYSTEM" == fedora-rawhide-* ]]
+    else
+        grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_amazon_linux() {
@@ -89,26 +91,25 @@ is_amazon_linux() {
 
 is_centos() {
     grep -qFx 'ID="centos"' /etc/os-release
-}
-
-is_centos_7() {
-    grep -qFx 'ID="centos"' /etc/os-release && grep -qFx 'VERSION_ID="7"' /etc/os-release
-}
-
-is_centos_8() {
-    grep -qFx 'ID="centos"' /etc/os-release && grep -qFx 'VERSION_ID="8"' /etc/os-release
-}
-
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID="centos"' /etc/os-release
+    else
+        grep -qFx 'ID="centos"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 is_arch_linux() {
     grep -qFx 'ID=arch' /etc/os-release
 }
 
 is_opensuse() {
-    grep -qFx 'ID="opensuse-leap"' /etc/os-release || grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
-}
-
-is_opensuse_tumbleweed() {
-    grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID="opensuse-leap"' /etc/os-release || grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    elif [ "$VERSION" == "tumbleweed" ]; then
+        grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    else
+        grep -qFx 'ID="centos"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_pc_amd64() {


### PR DESCRIPTION
Now the os.query allows to ask by the specific version of the system

I was replaced is-centos-8 by is-centos 8, which breaks backward
compatibility but is much easy to support new systems.

Also there are new OSs supported to keep compatibility with snapd
project