### PR TITLE
New remote and systemd tools with tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Run test
       run: |
-          spread google:tests/
+          spread google:tests/ google-nested:tests/

--- a/remote/remote.exec
+++ b/remote/remote.exec
@@ -35,6 +35,7 @@ _get_cert() {
 
 remote_exec() {
     local user pass
+    local timeout=10
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)
@@ -47,6 +48,10 @@ remote_exec() {
                 ;;
             --pass)
                 pass="$2"
+                shift 2
+                ;;
+            --timeout)
+                timeout="$2"
                 shift 2
                 ;;
             -*)
@@ -71,7 +76,7 @@ remote_exec() {
     SSH_PASS="$(_get_pass)"
     SSH_CERT="$(_get_cert)"
 
-    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
+    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ConnectTimeout="$timeout" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
 }
 
 main() {    

--- a/remote/remote.exec
+++ b/remote/remote.exec
@@ -71,7 +71,7 @@ remote_exec() {
     SSH_PASS="$(_get_pass)"
     SSH_CERT="$(_get_cert)"
 
-    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
+    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
 }
 
 main() {    

--- a/remote/remote.refresh
+++ b/remote/remote.refresh
@@ -1,98 +1,151 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 show_help() {
-    echo "usage: remote.refresh [--channel CHANNEL] [--snap SNAPNAME]"
+    echo "usage: remote.refresh snap [--channel CHANNEL] <SNAPNAME>"
+    echo "usage: remote.refresh full [--channel CHANNEL]"
+    echo ""
+    echo "SNAPNAME: allowed options are: kernel, core, base, gadget, snapd or the snap name"
     echo ""
     echo "Available options:"
     echo "  -h --help   show this help message."
     echo ""
 }
 
-check_refresh(){
+check_refresh_after_reboot() {
     local refresh_channel=$1
     local snap=$2
 
-    remote.wait-for no-ssh -n 30 --wait 2
+    remote.wait-for no-ssh -n 60 --wait 2
     remote.wait-for ssh -n 120 --wait 2
-    remote.retry -n 10 --wait 2  "snap info $snap | grep \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
+    remote.wait-for snap-command
+    remote.retry -n 10 --wait 2  "snap info $snap | grep -q -E \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
 }
 
+check_refresh() {
+    local refresh_channel=$1
+    local snap=$2
+
+    remote.wait-for ssh -n 60 --wait 2
+    remote.wait-for snap-command
+    remote.retry -n 10 --wait 2  "snap info $snap | grep -q -E \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
+}
+
+do_refresh() {
+    local snap_name=$1
+    local refresh_channel=$2
+
+    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $snap_name 2>&1" || echo "snapd is about to reboot the system")
+    if echo "$output" | grep -E "(no updates available|cannot refresh \"$snap_name\"|is not installed)"; then
+        echo "remote.refresh: snap \"$snap_name\" has no updates available"
+    elif echo "$output" | grep -E "snapd is about to reboot the system"; then
+        check_refresh_after_reboot "$refresh_channel" "$snap_name"
+    else
+        check_refresh "$refresh_channel" "$snap_name"
+    fi
+}
+
+process_line() {
+    local snap_line=$1
+    local refresh_channel=$2
+
+    snap_name=$(echo "$snap_line" | awk '{ print $1 }')
+    snap_channel=$(echo "$snap_line" | awk '{ print $4 }')
+    
+    if [ -z "$refresh_channel" ]; then
+        refresh_channel="$snap_channel"
+    fi
+
+    do_refresh "$snap_name" "$refresh_channel"
+}
 
 refresh_kernel() {
     local refresh_channel=$1
-    local kernel_line kernel_name kernel_channel
+    local kernel_line snap_name kernel_channel
 
-    kernel_line=$(remote.exec "snap list | grep -E 'kernel$'")
+    check_ubuntu_core
+    kernel_line=$(remote.exec "snap list | grep -E ' kernel$'")
     if [ -z "$kernel_line" ]; then
         echo "remote.refresh: no kernel snap to update"
         return
     fi
-    kernel_name=$(echo "$kernel_line" | awk '{ print $1 }')
-    kernel_channel=$(echo "$kernel_line" | awk '{ print $4 }')
+
+    process_line "$kernel_line" "$refresh_channel"
+}
+
+refresh_gadget() {
+    local refresh_channel=$1
+    local gadget_line snap_name gadget_channel
+
+    check_ubuntu_core
+    gadget_line=$(remote.exec "snap list | grep -E ' gadget$'")
+    if [ -z "$gadget_line" ]; then
+        echo "remote.refresh: no gadget snap to update"
+        return
+    fi
     
-    if [ -z "$refresh_channel" ]; then
-        refresh_channel="$kernel_channel"
-    fi
-
-    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $kernel_name 2>&1" || true)
-    if echo "$output" | grep -E "(no updates available|cannot refresh \"$kernel_name\"|is not installed)"; then
-        echo "remote.refresh: snap \"$kernel_name\" has no updates available"
-    else
-        check_refresh "$refresh_channel" "$kernel_name"
-    fi
+    process_line "$gadget_line" "$refresh_channel"
 }
 
-refresh_snapd(){
+refresh_snapd() {
     local refresh_channel=$1
-    local snapd_line snapd_name snapd_channel
+    local snapd_line snap_name snapd_channel
 
-    snapd_line=$(remote.exec "snap list | grep -E 'snapd$'")
-    if [ -z "$snapd_line" ]; then
+    if ! snapd_line="$(remote.exec "snap list | grep -E '^snapd.* snapd$'")"; then
         echo "remote.refresh: no snapd snap to update"
-        return
-    fi
-    snapd_name=$(echo "$snapd_line" | awk '{ print $1 }')
-    snapd_channel=$(echo "$snapd_line" | awk '{ print $4 }')
-
-    if [ -z "$refresh_channel" ]; then
-        refresh_channel="$snapd_channel"
+        return 0
     fi
 
-    # Run update and make "|| true" to continue when the connection is closed by remote host
-    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $snapd_name 2>&1" || true)
-    if echo "$output" | grep -E "(no updates available|cannot refresh \"$snapd_name\"|is not installed)"; then
-        echo "remote.refresh: snap \"$snapd_name\" has no updates available"
-    else
-        check_refresh "$refresh_channel" "$snapd_name"
-    fi
+    process_line "$snapd_line" "$refresh_channel"
 }
 
-refresh_core(){
+refresh_core() {
     local refresh_channel=$1
-    local core_line core_name core_channel
+    local core_line snap_name core_channel
 
-    core_line=$(remote.exec "snap list | grep -E '(core18|core20|core22)'")
-    if [ -z "$core_line" ]; then
+    if ! core_line="$(remote.exec "snap list | grep -E '^core.* core$'")"; then
         echo "remote.refresh: no core snap to update"
-        return
-    fi
-    core_name=$(echo "$core_line" | awk '{ print $1 }')
-    core_channel=$(echo "$core_line" | awk '{ print $4 }')
-
-    if [ -z "$refresh_channel" ]; then
-        refresh_channel="$core_channel"
+        return 0
     fi
 
-    # Run update and make "|| true" to continue when the connection is closed by remote host
-    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $core_name 2>&1" || true)
-    if echo "$output" | grep -E "(no updates available|cannot refresh \"$core_name\"|is not installed)"; then
-        echo "remote.refresh: snap \"$core_name\" has no updates available"
-    else
-        check_refresh "$refresh_channel" "$core_name"
-    fi
+    process_line "$core_line" "$refresh_channel"
 }
 
-refresh_all(){
+refresh_core_base() {
+    local refresh_channel=$1
+    local base_line snap_name core_channel
+
+    if ! base_line="$(remote.exec "snap list | grep -E '^core.* base$'")"; then
+        echo "remote.refresh: no core base snap to update"
+        return 0
+    fi
+
+    if [ "$(echo "$base_line" | wc -l)" -gt 1 ]; then
+        echo "remote.refresh: there is more than 1 core base snap to update, skipping"
+        return 0
+    fi
+
+    process_line "$base_line" "$refresh_channel"
+}
+
+refresh_snap() {
+    local snapname=$1
+    local refresh_channel=$2
+
+    if [ -z "$snapname" ]; then
+        echo "remote.refresh: snap name to refresh is not specified"
+        return 1
+    fi
+
+    if ! remote.exec "snap list $snapname"; then
+        echo "remote.refresh: no $snapname snap to update"
+        return 0
+    fi
+
+    snap_line="$(remote.exec "snap list $snapname" | tail -1)"
+    process_line "$snap_line" "$refresh_channel"
+}
+
+refresh_all() {
     # Run update and make "|| true" to continue when the connection is closed by remote host or not any snap to update
     remote.exec "sudo snap refresh" || true
     remote.wait-for ssh
@@ -103,86 +156,101 @@ get_boot_id() {
     remote.exec "cat /proc/sys/kernel/random/boot_id"
 }
 
-
-full_refresh(){
+full_refresh() {
     remote.wait-for auto-refresh
-    refresh_core "$core_channel"
+    refresh_core
     remote.wait-for auto-refresh
-    refresh_snapd "$snapd_channel"
+    refresh_core_base
     remote.wait-for auto-refresh
-    refresh_kernel "$kernel_channel"
+    refresh_snapd
+    remote.wait-for auto-refresh
+    refresh_kernel
     refresh_all
 }
 
-
-
-main() {
-    local action wait attempts others
-    case "$1" in
-        -h|--help)
-            show_help
-            exit
-            ;;
-        ssh)
-            action=wait_for_ssh
-            attempts=800
-            wait=1
-            shift
-            ;;
-        no-ssh)
-            action=wait_for_no_ssh
-            attempts=200
-            wait=1
-            shift
-            ;;
-        snap-command)
-            action=wait_for_snap_command
-            attempts=200
-            wait=1
-            shift
-            ;;
-        reboot)
-            action=wait_for_reboot
-            attempts=150
-            wait=5
-            shift
-            ;;
-        device-initialized)
-            action=wait_for_device_initialized
-            attempts=60
-            wait=1
-            shift
-            ;;
-        *)
-            echo "remote.wait-for: unsupported parameter $1" >&2
-            exit 1
-            ;;
-    esac
-
-    if [ -z "$(declare -f "$action")" ]; then
-        echo "remote.wait-for: no such command: $action"
-        show_help
-        exit 1
-    fi
+snap_refresh() {
+    local channel snapname
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --wait)                
-                wait=$2
-                shift 2
-                ;;
-            --attempts|-n)                
-                attempts=$2
+            --channel)
+                channel=$2
                 shift 2
                 ;;
             *)
-                others="$others $1"
+                snapname=$1
                 shift
                 ;;
         esac
     done
 
-    "$action" "$attempts" "$wait" "$others"
+    if [ -z "$snapname" ]; then
+        echo "remote.refresh: snap name to refresh is not specified"
+        return 1
+    fi
+
+    case "$snapname" in
+        core)
+            refresh_core "$channel"
+            ;;
+        base)
+            refresh_core_base "$channel"
+            ;;
+        snapd)
+            refresh_snapd "$channel"
+            ;;
+        kernel)
+            refresh_kernel "$channel"
+            ;;
+        gadget)
+            refresh_gadget "$channel"
+            ;;
+        *)
+            refresh_snap "$snapname" "$channel"
+            ;;
+    esac
+}
+
+check_ubuntu_core() {
+    if ! remote.exec "cat /etc/os-release | grep ID=ubuntu-core"; then
+        echo "remote.refresh: this function can be used just with ubuntu core systems"
+        return 1
+    fi
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit
+    fi
+
+    local action
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        full)
+            action=full_refresh
+            shift
+            ;;
+        snap)
+            action=snap_refresh
+            shift
+            ;;
+        *)
+            echo "remote.refresh: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "remote.refresh: no such command: $action"
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
 }
 
 main "$@"

--- a/remote/remote.refresh
+++ b/remote/remote.refresh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 show_help() {
     echo "usage: remote.refresh snap [--channel CHANNEL] <SNAPNAME>"
@@ -38,21 +38,21 @@ do_refresh() {
     if echo "$output" | grep -E "(no updates available|cannot refresh \"$snap_name\"|is not installed)"; then
         echo "remote.refresh: snap \"$snap_name\" has no updates available"
     elif echo "$output" | grep -E "snapd is about to reboot the system"; then
+        remote.exec --timeout 3 "sudo reboot" || true
         check_refresh_after_reboot "$refresh_channel" "$snap_name"
     else
         check_refresh "$refresh_channel" "$snap_name"
     fi
 }
 
-process_line() {
-    local snap_line=$1
+process_refresh() {
+    local snap_name=$1
     local refresh_channel=$2
-
-    snap_name=$(echo "$snap_line" | awk '{ print $1 }')
-    snap_channel=$(echo "$snap_line" | awk '{ print $4 }')
     
     if [ -z "$refresh_channel" ]; then
-        refresh_channel="$snap_channel"
+        # Tracking is retrieved from snap info command because in old versions of
+        # snapd the tracking is not included in the snap list output
+        refresh_channel="$(snap info "$snap_name" | grep -E '^tracking:' |  awk '{ print $2 }')"
     fi
 
     do_refresh "$snap_name" "$refresh_channel"
@@ -60,61 +60,63 @@ process_line() {
 
 refresh_kernel() {
     local refresh_channel=$1
-    local kernel_line snap_name kernel_channel
+    local snap_name
 
     check_ubuntu_core
-    kernel_line=$(remote.exec "snap list | grep -E ' kernel$'")
-    if [ -z "$kernel_line" ]; then
+    snap_name="$(remote.exec "snap list" | grep -E '(kernel$|kernel,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
         echo "remote.refresh: no kernel snap to update"
         return
     fi
 
-    process_line "$kernel_line" "$refresh_channel"
+    process_refresh "$snap_name" "$refresh_channel"
 }
 
 refresh_gadget() {
     local refresh_channel=$1
-    local gadget_line snap_name gadget_channel
+    local snap_name
 
     check_ubuntu_core
-    gadget_line=$(remote.exec "snap list | grep -E ' gadget$'")
-    if [ -z "$gadget_line" ]; then
+    snap_name="$(remote.exec "snap list" | grep -E '(gadget$|gadget,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
         echo "remote.refresh: no gadget snap to update"
         return
     fi
     
-    process_line "$gadget_line" "$refresh_channel"
+    process_refresh "$snap_name" "$refresh_channel"
 }
 
 refresh_snapd() {
     local refresh_channel=$1
-    local snapd_line snap_name snapd_channel
+    local snap_name
 
-    if ! snapd_line="$(remote.exec "snap list | grep -E '^snapd.* snapd$'")"; then
+    snap_name="$(remote.exec "snap list" | grep -E '^snapd.*(snapd$|snapd,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
         echo "remote.refresh: no snapd snap to update"
         return 0
     fi
 
-    process_line "$snapd_line" "$refresh_channel"
+    process_refresh "$snap_name" "$refresh_channel"
 }
 
 refresh_core() {
     local refresh_channel=$1
-    local core_line snap_name core_channel
+    local snap_name
 
-    if ! core_line="$(remote.exec "snap list | grep -E '^core.* core$'")"; then
+    snap_name="$(remote.exec "snap list" | grep -E '^core.*(core$|core,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
         echo "remote.refresh: no core snap to update"
         return 0
     fi
 
-    process_line "$core_line" "$refresh_channel"
+    process_refresh "$snap_name" "$refresh_channel"
 }
 
 refresh_core_base() {
     local refresh_channel=$1
     local base_line snap_name core_channel
 
-    if ! base_line="$(remote.exec "snap list | grep -E '^core.* base$'")"; then
+    if ! base_line="$(remote.exec "snap list | grep -E '^core.* (base$|base,)'")"; then
         echo "remote.refresh: no core base snap to update"
         return 0
     fi
@@ -124,7 +126,7 @@ refresh_core_base() {
         return 0
     fi
 
-    process_line "$base_line" "$refresh_channel"
+    process_refresh "$base_line" "$refresh_channel"
 }
 
 refresh_snap() {
@@ -142,7 +144,7 @@ refresh_snap() {
     fi
 
     snap_line="$(remote.exec "snap list $snapname" | tail -1)"
-    process_line "$snap_line" "$refresh_channel"
+    process_refresh "$snap_line" "$refresh_channel"
 }
 
 refresh_all() {

--- a/remote/remote.refresh
+++ b/remote/remote.refresh
@@ -52,7 +52,7 @@ process_refresh() {
     if [ -z "$refresh_channel" ]; then
         # Tracking is retrieved from snap info command because in old versions of
         # snapd the tracking is not included in the snap list output
-        refresh_channel="$(snap info "$snap_name" | grep -E '^tracking:' |  awk '{ print $2 }')"
+        refresh_channel="$(remote.exec "snap info $snap_name" | grep -E '^tracking:' |  awk '{ print $2 }')"
     fi
 
     do_refresh "$snap_name" "$refresh_channel"

--- a/remote/remote.refresh
+++ b/remote/remote.refresh
@@ -1,0 +1,188 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.refresh [--channel CHANNEL] [--snap SNAPNAME]"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+check_refresh(){
+    local refresh_channel=$1
+    local snap=$2
+
+    remote.wait-for no-ssh -n 30 --wait 2
+    remote.wait-for ssh -n 120 --wait 2
+    remote.retry -n 10 --wait 2  "snap info $snap | grep \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
+}
+
+
+refresh_kernel() {
+    local refresh_channel=$1
+    local kernel_line kernel_name kernel_channel
+
+    kernel_line=$(remote.exec "snap list | grep -E 'kernel$'")
+    if [ -z "$kernel_line" ]; then
+        echo "remote.refresh: no kernel snap to update"
+        return
+    fi
+    kernel_name=$(echo "$kernel_line" | awk '{ print $1 }')
+    kernel_channel=$(echo "$kernel_line" | awk '{ print $4 }')
+    
+    if [ -z "$refresh_channel" ]; then
+        refresh_channel="$kernel_channel"
+    fi
+
+    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $kernel_name 2>&1" || true)
+    if echo "$output" | grep -E "(no updates available|cannot refresh \"$kernel_name\"|is not installed)"; then
+        echo "remote.refresh: snap \"$kernel_name\" has no updates available"
+    else
+        check_refresh "$refresh_channel" "$kernel_name"
+    fi
+}
+
+refresh_snapd(){
+    local refresh_channel=$1
+    local snapd_line snapd_name snapd_channel
+
+    snapd_line=$(remote.exec "snap list | grep -E 'snapd$'")
+    if [ -z "$snapd_line" ]; then
+        echo "remote.refresh: no snapd snap to update"
+        return
+    fi
+    snapd_name=$(echo "$snapd_line" | awk '{ print $1 }')
+    snapd_channel=$(echo "$snapd_line" | awk '{ print $4 }')
+
+    if [ -z "$refresh_channel" ]; then
+        refresh_channel="$snapd_channel"
+    fi
+
+    # Run update and make "|| true" to continue when the connection is closed by remote host
+    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $snapd_name 2>&1" || true)
+    if echo "$output" | grep -E "(no updates available|cannot refresh \"$snapd_name\"|is not installed)"; then
+        echo "remote.refresh: snap \"$snapd_name\" has no updates available"
+    else
+        check_refresh "$refresh_channel" "$snapd_name"
+    fi
+}
+
+refresh_core(){
+    local refresh_channel=$1
+    local core_line core_name core_channel
+
+    core_line=$(remote.exec "snap list | grep -E '(core18|core20|core22)'")
+    if [ -z "$core_line" ]; then
+        echo "remote.refresh: no core snap to update"
+        return
+    fi
+    core_name=$(echo "$core_line" | awk '{ print $1 }')
+    core_channel=$(echo "$core_line" | awk '{ print $4 }')
+
+    if [ -z "$refresh_channel" ]; then
+        refresh_channel="$core_channel"
+    fi
+
+    # Run update and make "|| true" to continue when the connection is closed by remote host
+    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $core_name 2>&1" || true)
+    if echo "$output" | grep -E "(no updates available|cannot refresh \"$core_name\"|is not installed)"; then
+        echo "remote.refresh: snap \"$core_name\" has no updates available"
+    else
+        check_refresh "$refresh_channel" "$core_name"
+    fi
+}
+
+refresh_all(){
+    # Run update and make "|| true" to continue when the connection is closed by remote host or not any snap to update
+    remote.exec "sudo snap refresh" || true
+    remote.wait-for ssh
+}
+
+
+get_boot_id() {
+    remote.exec "cat /proc/sys/kernel/random/boot_id"
+}
+
+
+full_refresh(){
+    remote.wait-for auto-refresh
+    refresh_core "$core_channel"
+    remote.wait-for auto-refresh
+    refresh_snapd "$snapd_channel"
+    remote.wait-for auto-refresh
+    refresh_kernel "$kernel_channel"
+    refresh_all
+}
+
+
+
+main() {
+    local action wait attempts others
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        ssh)
+            action=wait_for_ssh
+            attempts=800
+            wait=1
+            shift
+            ;;
+        no-ssh)
+            action=wait_for_no_ssh
+            attempts=200
+            wait=1
+            shift
+            ;;
+        snap-command)
+            action=wait_for_snap_command
+            attempts=200
+            wait=1
+            shift
+            ;;
+        reboot)
+            action=wait_for_reboot
+            attempts=150
+            wait=5
+            shift
+            ;;
+        device-initialized)
+            action=wait_for_device_initialized
+            attempts=60
+            wait=1
+            shift
+            ;;
+        *)
+            echo "remote.wait-for: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "remote.wait-for: no such command: $action"
+        show_help
+        exit 1
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --wait)                
+                wait=$2
+                shift 2
+                ;;
+            --attempts|-n)                
+                attempts=$2
+                shift 2
+                ;;
+            *)
+                others="$others $1"
+                shift
+                ;;
+        esac
+    done
+
+    "$action" "$attempts" "$wait" "$others"
+}
+
+main "$@"

--- a/remote/remote.retry
+++ b/remote/remote.retry
@@ -23,7 +23,6 @@ remote_retry(){
     done
 }
 
-
 main() {
     local wait attempts cmd
     wait=1
@@ -44,12 +43,17 @@ main() {
                 shift 2
                 ;;
             *)
-                cmd="$@"
                 break
                 ;;
         esac
     done
 
+    if [ $# -eq 0 ]; then
+        echo "remote.retry: command to retry not specified"
+        return 1
+    fi
+
+    remote_retry "$attempts" "$wait" "$@"
 }
 
-remote_retry "$attempts" "$wait" "$cmd"
+main "$@"

--- a/remote/remote.retry
+++ b/remote/remote.retry
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.retry [--wait WAIT] [-n|--attempts ATTEMPTS] <CMD>"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+remote_retry(){
+    local attempts=$1
+    local wait=$2
+    local cmd=$3
+
+    while ! remote.exec "$cmd"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.retry: timed out retrying command"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+
+main() {
+    local wait attempts cmd
+    wait=1
+    attempts=30
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit
+                ;;
+            --wait)
+                wait=$2
+                shift 2
+                ;;
+            --attempts|-n)
+                attempts=$2
+                shift 2
+                ;;
+            *)
+                cmd="$@"
+                break
+                ;;
+        esac
+    done
+
+}
+
+remote_retry "$attempts" "$wait" "$cmd"

--- a/remote/remote.wait-for
+++ b/remote/remote.wait-for
@@ -64,7 +64,7 @@ wait_for_reboot() {
     local attempts=$1
     local wait=$2
     local initial_boot_id=$3
-    local last_boot_id="$initial_boot_id"
+    local last_boot_id
 
     if [ -z "$initial_boot_id" ]; then
         echo "remote.wait-for: initial boot id not set"
@@ -181,7 +181,11 @@ main() {
                 shift 2
                 ;;
             *)
-                others="$others $1"
+                if [ -z "$others" ]; then
+                    others=$1
+                else
+                    others="$others $1"
+                fi
                 shift
                 ;;
         esac

--- a/remote/remote.wait-for
+++ b/remote/remote.wait-for
@@ -1,0 +1,192 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.wait-for ssh [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for no-ssh  [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for snap-command [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for reboot [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for device-initialized [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+wait_for_ssh() {
+    local attempts=$1
+    local wait=$2
+
+    until remote.exec "true"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "Timed out waiting for command 'true' to succeed. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+wait_for_no_ssh() {
+    local attempts=$1
+    local wait=$2
+
+    while remote.exec "true"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "Timed out waiting for command 'true' to fail. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+
+wait_for_snap_command() {
+    local attempts=$1
+    local wait=$2
+
+    while ! remote.exec "command -v snap"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "Timed out waiting for command 'command -v snap' to success. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+get_boot_id() {
+    remote.exec "cat /proc/sys/kernel/random/boot_id"
+}
+
+wait_for_reboot() {
+    local attempts=$1
+    local wait=$2
+    local initial_boot_id=$3
+    local last_boot_id="$initial_boot_id"
+
+    if [ -z "$initial_boot_id" ]; then
+        echo "remote.wait-for: initial boot id not set"
+        return 1
+    fi
+
+    while [ $attempts -ge 0 ]; do
+        attempts=$(( attempts - 1 ))
+        # The get_boot_id could fail because the connection is broken due to the reboot
+        last_boot_id="$(get_boot_id)" || true
+        if [[ "$last_boot_id" =~ .*-.*-.*-.*-.* ]] && [ "$last_boot_id" != "$initial_boot_id" ]; then
+            break
+        fi
+        sleep "$wait"
+    done
+
+    [ "$last_boot_id" != "$initial_boot_id" ]
+}
+
+wait_for_device_initialized() {
+    local attempts=$1
+    local wait=$2
+
+    while ! remote.exec "snap changes" | grep -Eq "Done.*Initialize device"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.wait-for: timed out waiting for device to be fully initialized. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+wait_auto_refresh(){
+    if remote.exec "snap changes" | grep -q -E "Doing.*Auto-refresh snap.*"; then
+        remote.retry -n 120 --wait 5  "snap changes | grep \"Doing.*Auto-refresh.*\""
+        wait_for_ssh -n 120 --wait 5
+        
+        if remote.exec "snap changes" | grep "Error.*Auto-refresh.*"; then
+            echo "remote.wait-for: auto-refresh failed"
+            return 1
+        fi
+
+        remote.retry -n 120 --wait 4  "snap changes | grep \"Done.*Auto-refresh.*\""
+    fi
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit
+    fi
+
+    local action wait attempts others
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        ssh)
+            action=wait_for_ssh
+            attempts=800
+            wait=1
+            shift
+            ;;
+        no-ssh)
+            action=wait_for_no_ssh
+            attempts=200
+            wait=1
+            shift
+            ;;
+        snap-command)
+            action=wait_for_snap_command
+            attempts=200
+            wait=1
+            shift
+            ;;
+        reboot)
+            action=wait_for_reboot
+            attempts=150
+            wait=5
+            shift
+            ;;
+        device-initialized)
+            action=wait_for_device_initialized
+            attempts=60
+            wait=1
+            shift
+            ;;
+        auto-refresh)
+            action=wait_auto_refresh
+            shift
+            ;;
+        *)
+            echo "remote.wait-for: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "remote.wait-for: no such command: $action"
+        show_help
+        exit 1
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --wait)
+                wait=$2
+                shift 2
+                ;;
+            --attempts|-n)
+                attempts=$2
+                shift 2
+                ;;
+            *)
+                others="$others $1"
+                shift
+                ;;
+        esac
+    done
+
+    "$action" "$attempts" "$wait" "$others"
+}
+
+main "$@"

--- a/remote/remote.wait-for
+++ b/remote/remote.wait-for
@@ -6,6 +6,7 @@ show_help() {
     echo "       remote.wait-for snap-command [--wait WAIT] [-n|--attempts ATTEMPTS]"
     echo "       remote.wait-for reboot [--wait WAIT] [-n|--attempts ATTEMPTS]"
     echo "       remote.wait-for device-initialized [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for auto-refresh [--wait WAIT] [-n|--attempts ATTEMPTS]"
     echo ""
     echo "Available options:"
     echo "  -h --help   show this help message."
@@ -19,7 +20,7 @@ wait_for_ssh() {
     until remote.exec "true"; do
         attempts=$(( attempts - 1 ))
         if [ $attempts -le 0 ]; then
-            echo "Timed out waiting for command 'true' to succeed. Aborting!"
+            echo "remote.wait-for: timed out waiting for ssh connection to succeed"
             return 1
         fi
         sleep "$wait"
@@ -33,7 +34,7 @@ wait_for_no_ssh() {
     while remote.exec "true"; do
         attempts=$(( attempts - 1 ))
         if [ $attempts -le 0 ]; then
-            echo "Timed out waiting for command 'true' to fail. Aborting!"
+            echo "remote.wait-for: timed out waiting for ssh connection to fail"
             return 1
         fi
         sleep "$wait"
@@ -45,10 +46,10 @@ wait_for_snap_command() {
     local attempts=$1
     local wait=$2
 
-    while ! remote.exec "command -v snap"; do
+    while ! remote.exec "command -v snap >/dev/null"; do
         attempts=$(( attempts - 1 ))
         if [ $attempts -le 0 ]; then
-            echo "Timed out waiting for command 'command -v snap' to success. Aborting!"
+            echo "remote.wait-for: timed out waiting for snap command to succeed"
             return 1
         fi
         sleep "$wait"

--- a/spread.yaml
+++ b/spread.yaml
@@ -35,6 +35,18 @@ backends:
             - opensuse-15.4-64:
             - opensuse-tumbleweed-64:
 
+    google-nested:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: snapd-spread/us-east1-b
+        plan: n2-standard-2
+        halt-timeout: 2h
+        cpu-family: "Intel Cascade Lake"
+        systems:
+            - ubuntu-20.04-64:
+                  image: ubuntu-2004-64-virt-enabled
+                  storage: 20G
+                  workers: 1
 
 path: /root/snapd-testing-tools
 

--- a/tests/check-test-format/task.yaml
+++ b/tests/check-test-format/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread checker tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/log-analyzer/task.yaml
+++ b/tests/log-analyzer/task.yaml
@@ -1,5 +1,7 @@
 summary: integration tests for log-analyzer tool
 
+backends: [google]
+
 # Github actions agents are just running in bionic and focal
 systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 

--- a/tests/log-parser/task.yaml
+++ b/tests/log-parser/task.yaml
@@ -1,5 +1,7 @@
 summary: test for the log parser tool
 
+backends: [google]
+
 # Github actions agents are just running in bionic and focal
 systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 

--- a/tests/not/task.yaml
+++ b/tests/not/task.yaml
@@ -1,4 +1,6 @@
 summary: test for the not tool
 
+backends: [google]
+
 execute: |
     not false && echo test | MATCH test

--- a/tests/os.paths/task.yaml
+++ b/tests/os.paths/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the os.paths tool
 
+backends: [google]
+
 execute: |
     os.paths --help | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'
     os.paths -h | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'

--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the os.query tool
 
+backends: [google]
+
 execute: |
     os.query --help | MATCH 'usage: os.query is-core, is-classic'
     os.query -h | MATCH 'usage: os.query is-core, is-classic'

--- a/tests/remote.exec/task.yaml
+++ b/tests/remote.exec/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the remote.exec tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 

--- a/tests/remote.exec/task.yaml
+++ b/tests/remote.exec/task.yaml
@@ -7,6 +7,7 @@ systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -14,9 +15,7 @@ restore: |
 
 execute: |
     remote.exec --help | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'
-    remote.exec -h | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'
-
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
+    remote.exec -h | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'    
 
     remote.exec "touch testfile"
     test -f /home/tools-user-1/testfile

--- a/tests/remote.pull/task.yaml
+++ b/tests/remote.pull/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the remote.pull tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 

--- a/tests/remote.pull/task.yaml
+++ b/tests/remote.pull/task.yaml
@@ -7,6 +7,7 @@ systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -17,7 +18,6 @@ execute: |
     remote.pull -h | MATCH 'usage: remote.pull <REMOTE_PATH> <LOCAL_PATH>'
 
     # check basic pull 
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
     touch /home/tools-user-1/testfile
     remote.pull testfile .
     test -f testfile

--- a/tests/remote.push/task.yaml
+++ b/tests/remote.push/task.yaml
@@ -7,6 +7,7 @@ systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -17,7 +18,6 @@ execute: |
     remote.push -h | MATCH 'usage: remote.push <LOCAL_PATH> <REMOTE_PATH>'
 
     # check basic push 
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
     touch testfile
     remote.push testfile "/home/tools-user-1"
     test -f /home/tools-user-1/testfile

--- a/tests/remote.push/task.yaml
+++ b/tests/remote.push/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the remote.push tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 

--- a/tests/remote.refresh/task.yaml
+++ b/tests/remote.refresh/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the remote.wait-for tool
 
-bachends: [google-nested]
+backends: [google-nested]
 
 systems: [ubuntu-20.04-64]
 

--- a/tests/remote.refresh/task.yaml
+++ b/tests/remote.refresh/task.yaml
@@ -1,0 +1,58 @@
+summary: smoke test for the remote.wait-for tool
+
+bachends: [google-nested]
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    user: test
+    pass: ubuntu
+    host: localhost
+    port: 8022
+    unit: nested-vm
+    TARGET/xenial: xenial
+    TARGET/bionic: bionic
+
+prepare: |
+    if [ "$TARGET" = xenial ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-16-stable-core_beta_2.56.2.img.xz
+    elif [ "$TARGET" = bionic ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-18-stable-snapd_beta_2.56.2.img.xz
+    fi
+    unxz pc.img.xz
+
+    service_line="kvm -nographic -snapshot -smp 2 -m 1500 -net nic,model=virtio -net user,hostfwd=tcp::$port-:22 -serial mon:stdio $PWD/pc.img"
+    tests.systemd create-and-start-unit "$unit" "$service_line"
+
+    remote.setup config --host "$host" --port "$port" --user "$user" --pass "$pass"
+
+restore: |
+    tests.systemd stop-and-remove-unit "$unit"    
+    rm -f pc.img "$(remote.setup get-config-path)"
+
+execute: |
+    remote.refresh | MATCH 'usage: remote.refresh snap'
+    remote.refresh -h | MATCH 'usage: remote.refresh snap'
+    remote.refresh --help | MATCH 'usage: remote.refresh snap'
+
+    # check the vm already started
+    remote.wait-for ssh
+    remote.wait-for device-initialized
+    remote.wait-for snap-command
+
+    # Check waiting when reboot
+    remote.refresh full
+
+    if [ "$TARGET" = xenial ]; then
+        remote.refresh snap kernel --channel latest/beta
+        remote.wait-for auto-refresh
+        remote.refresh snap kernel --channel latest/stable
+        remote.wait-for auto-refresh
+        remote.refresh snap core --channel stable
+    elif [ "$TARGET" = bionic ]; then
+        remote.refresh snap kernel --channel 18/beta
+        remote.wait-for auto-refresh
+        remote.refresh snap kernel --channel 18/stable
+        remote.wait-for auto-refresh
+        remote.refresh snap snapd --channel stable
+    fi

--- a/tests/remote.refresh/task.yaml
+++ b/tests/remote.refresh/task.yaml
@@ -46,13 +46,9 @@ execute: |
     if [ "$TARGET" = xenial ]; then
         remote.refresh snap kernel --channel latest/beta
         remote.wait-for auto-refresh
-        remote.refresh snap kernel --channel latest/stable
-        remote.wait-for auto-refresh
         remote.refresh snap core --channel stable
     elif [ "$TARGET" = bionic ]; then
         remote.refresh snap kernel --channel 18/beta
-        remote.wait-for auto-refresh
-        remote.refresh snap kernel --channel 18/stable
         remote.wait-for auto-refresh
         remote.refresh snap snapd --channel stable
     fi

--- a/tests/remote.retry/task.yaml
+++ b/tests/remote.retry/task.yaml
@@ -21,7 +21,7 @@ execute: |
     remote.retry "true"
 
     # check negative scenario
-    ! remote.retry --wait 1 -attempts 2 "false"
+    not remote.retry --wait 1 -attempts 2 "false"
 
     # check the command is executed correctly
     rm -f /tmp/my-remote-retry-test
@@ -29,15 +29,15 @@ execute: |
     test -f /tmp/my-remote-retry-test
 
     # check the --attempts and --wait parameter
-    ! remote.retry --wait 0.5 --attempts 5 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    not remote.retry --wait 0.5 --attempts 5 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
     test "$(grep -c 1 /tmp/my-remote-retry-test)" = 5
     rm -f /tmp/my-remote-retry-test
 
     # check the -n parameter
-    ! remote.retry --wait 0.5 -n 8 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    not remote.retry --wait 0.5 -n 8 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
     test "$(grep -c 1 /tmp/my-remote-retry-test)" = 8
     rm -f /tmp/my-remote-retry-test
 
     # check errors
-    remote.retry --wait 0.5 -n 2 "false" 2>1 | MATCH "remote.retry: timed out retrying command"
-    remote.retry 2>1 | MATCH "remote.retry: command to retry not specified"
+    remote.retry --wait 0.5 -n 2 "false" 2>&1 | MATCH "remote.retry: timed out retrying command"
+    remote.retry 2>&1 | MATCH "remote.retry: command to retry not specified"

--- a/tests/remote.retry/task.yaml
+++ b/tests/remote.retry/task.yaml
@@ -1,0 +1,43 @@
+summary: smoke test for the remote.retry tool
+
+backends: [google]
+
+# Amazon linux is skipped because no sshpass available
+systems: [-amazon-linux-*]
+
+prepare: |
+    tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
+
+restore: |
+    tests.pkgs remove sshpass
+    rm -rf remote.setup.cfg /tmp/my-remote-retry-test
+
+execute: |
+    remote.retry --help | MATCH 'usage: remote.retry'
+    remote.retry -h | MATCH 'usage: remote.retry'
+
+    # check the possitive scenario without parameters
+    remote.retry "true"
+
+    # check negative scenario
+    ! remote.retry --wait 1 -attempts 2 "false"
+
+    # check the command is executed correctly
+    rm -f /tmp/my-remote-retry-test
+    remote.retry "touch /tmp/my-remote-retry-test"
+    test -f /tmp/my-remote-retry-test
+
+    # check the --attempts and --wait parameter
+    ! remote.retry --wait 0.5 --attempts 5 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    test "$(grep -c 1 /tmp/my-remote-retry-test)" = 5
+    rm -f /tmp/my-remote-retry-test
+
+    # check the -n parameter
+    ! remote.retry --wait 0.5 -n 8 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    test "$(grep -c 1 /tmp/my-remote-retry-test)" = 8
+    rm -f /tmp/my-remote-retry-test
+
+    # check erros
+    remote.retry --wait 0.5 -n 2 "false" 2>1 | MATCH "remote.retry: timed out retrying command"
+    remote.retry 2>1 | MATCH "remote.retry: command to retry not specified"

--- a/tests/remote.retry/task.yaml
+++ b/tests/remote.retry/task.yaml
@@ -17,7 +17,7 @@ execute: |
     remote.retry --help | MATCH 'usage: remote.retry'
     remote.retry -h | MATCH 'usage: remote.retry'
 
-    # check the possitive scenario without parameters
+    # check the positive scenario without parameters
     remote.retry "true"
 
     # check negative scenario
@@ -38,6 +38,6 @@ execute: |
     test "$(grep -c 1 /tmp/my-remote-retry-test)" = 8
     rm -f /tmp/my-remote-retry-test
 
-    # check erros
+    # check errors
     remote.retry --wait 0.5 -n 2 "false" 2>1 | MATCH "remote.retry: timed out retrying command"
     remote.retry 2>1 | MATCH "remote.retry: command to retry not specified"

--- a/tests/remote.setup/task.yaml
+++ b/tests/remote.setup/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the remote.setup tool
 
+backends: [google]
+
 restore: |
     rm -f remote.setup.cfg my-key my-key-2
 

--- a/tests/remote.wait-for/task.yaml
+++ b/tests/remote.wait-for/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the remote.wait-for tool
 
-bachends: [google-nested]
+backends: [google-nested]
 
 systems: [ubuntu-20.04-64]
 
@@ -55,16 +55,18 @@ execute: |
     remote.wait-for reboot --wait 5 -n 20 "$initial_boot_id"
 
     # Check waiting for reboot with not enough time
-    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'
+    # shellcheck disable=SC2016
+    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'    
     second_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
 
     remote.exec "sudo reboot" || true
-    ! remote.wait-for reboot --wait 1 -n 5 "$second_boot_id"
+    not remote.wait-for reboot --wait 1 -n 5 "$second_boot_id"
 
     # Check again if the device has been initialized and the snap command
     remote.wait-for device-initialized --wait 1 -n 60
     remote.wait-for snap-command
 
+    # shellcheck disable=SC2016
     remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'
     third_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
 

--- a/tests/remote.wait-for/task.yaml
+++ b/tests/remote.wait-for/task.yaml
@@ -55,7 +55,9 @@ execute: |
     remote.wait-for reboot --wait 5 -n 20 "$initial_boot_id"
 
     # Check waiting for reboot with not enough time
+    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'
     second_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+
     remote.exec "sudo reboot" || true
     ! remote.wait-for reboot --wait 1 -n 5 "$second_boot_id"
 
@@ -63,7 +65,10 @@ execute: |
     remote.wait-for device-initialized --wait 1 -n 60
     remote.wait-for snap-command
 
+    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'
     third_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
 
+    # Check boot ids are different
     test "$initial_boot_id" != "$second_boot_id"
     test "$second_boot_id" != "$third_boot_id"
+    

--- a/tests/remote.wait-for/task.yaml
+++ b/tests/remote.wait-for/task.yaml
@@ -60,7 +60,8 @@ execute: |
     second_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
 
     remote.exec "sudo reboot" || true
-    not remote.wait-for reboot --wait 1 -n 5 "$second_boot_id"
+    # shellcheck disable=SC2251
+    ! remote.wait-for reboot --wait 0.5 -n 5 "$second_boot_id"
 
     # Check again if the device has been initialized and the snap command
     remote.wait-for device-initialized --wait 1 -n 60

--- a/tests/remote.wait-for/task.yaml
+++ b/tests/remote.wait-for/task.yaml
@@ -1,0 +1,69 @@
+summary: smoke test for the remote.wait-for tool
+
+bachends: [google-nested]
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    user: test
+    pass: ubuntu
+    host: localhost
+    port: 8022
+    unit: nested-vm
+    TARGET/xenial: xenial
+    TARGET/bionic: bionic
+
+prepare: |
+    if [ "$TARGET" = xenial ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-16-stable-core_beta_2.56.2.img.xz
+    elif [ "$TARGET" = bionic ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-18-stable-snapd_beta_2.56.2.img.xz
+    fi
+    unxz pc.img.xz
+
+    service_line="kvm -nographic -snapshot -smp 2 -m 1500 -net nic,model=virtio -net user,hostfwd=tcp::$port-:22 -serial mon:stdio $PWD/pc.img"
+    tests.systemd create-and-start-unit "$unit" "$service_line"
+
+    remote.setup config --host "$host" --port "$port" --user "$user" --pass "$pass"
+
+restore: |
+    tests.systemd stop-and-remove-unit "$unit"    
+    rm -f pc.img "$(remote.setup get-config-path)"
+
+execute: |
+    remote.wait-for | MATCH 'usage: remote.wait-for ssh'
+    remote.wait-for -h | MATCH 'usage: remote.wait-for ssh'
+    remote.wait-for --help | MATCH 'usage: remote.wait-for ssh'
+
+    # check the vm already started
+    remote.wait-for ssh
+
+    # Check if the device has been initialized
+    remote.wait-for device-initialized
+
+    # Check if the device has snap command
+    remote.wait-for snap-command
+
+    # Check waiting when reboot
+    remote.exec "sudo reboot" || true
+    remote.wait-for no-ssh --wait 1 -n 20
+    remote.wait-for ssh --wait 1 -n 60
+
+    # Check waiting for reboot
+    initial_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+    remote.exec "sudo reboot" || true
+    remote.wait-for reboot --wait 5 -n 20 "$initial_boot_id"
+
+    # Check waiting for reboot with not enough time
+    second_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+    remote.exec "sudo reboot" || true
+    ! remote.wait-for reboot --wait 1 -n 5 "$second_boot_id"
+
+    # Check again if the device has been initialized and the snap command
+    remote.wait-for device-initialized --wait 1 -n 60
+    remote.wait-for snap-command
+
+    third_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+
+    test "$initial_boot_id" != "$second_boot_id"
+    test "$second_boot_id" != "$third_boot_id"

--- a/tests/repack-kernel/task.yaml
+++ b/tests/repack-kernel/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the repack-kernel tool
 
+backends: [google]
+
 # ubuntu-core-initramfs seems to be only available on ubuntu-20.04
 systems: [ubuntu-20.04-64]
 

--- a/tests/retry/task.yaml
+++ b/tests/retry/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the retry tool
 
+backends: [google]
+
 execute: |
     # Retry runs the command that was passed as argument and returns the exit
     # code of that command.

--- a/tests/snaps.cleanup/task.yaml
+++ b/tests/snaps.cleanup/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snaps.cleanup tool
 
+backends: [google]
+
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |

--- a/tests/snaps.name/task.yaml
+++ b/tests/snaps.name/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snaps.name tool
 
+backends: [google]
+
 execute: |
     snaps.name --help | MATCH 'usage: snaps.name gadget, kernel, core'
     snaps.name -h | MATCH 'usage: snaps.name gadget, kernel, core'

--- a/tests/spread-manager/task.yaml
+++ b/tests/spread-manager/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread-manager tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/spread-shellcheck/task.yaml
+++ b/tests/spread-shellcheck/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread-shellcheck tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/tests.backup/task.yaml
+++ b/tests/tests.backup/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the tests.backup tool
 
+backends: [google]
+
 execute: |
     # Without any arguments a help message is printed.
     tests.backup | MATCH "usage: tests.backup prepare"

--- a/tests/tests.cleanup/task.yaml
+++ b/tests/tests.cleanup/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the tests.cleanup tool
 
+backends: [google]
+
 systems: [ubuntu-18.04-64]
 
 execute: |

--- a/tests/tests.pkgs/task.yaml
+++ b/tests/tests.pkgs/task.yaml
@@ -1,5 +1,7 @@
 summary: Smoke test for tests.pkgs tool
 
+backends: [google]
+
 execute: |
     if os.query is-core; then
         tests.pkgs -h 2>&1 | MATCH 'tests.pkgs: Ubuntu Core is not supported'

--- a/tests/tests.systemd/task.yaml
+++ b/tests/tests.systemd/task.yaml
@@ -23,7 +23,7 @@ execute: |
     tests.systemd wait-for-service my-test active
     tests.systemd wait-for-service my-test inactive
     tests.systemd stop-and-remove-unit my-test
-    systemctl status my-test 2>&1 | MATCH "Unit my-test.service could not be found."
+    systemctl list-unit-files | NOMATCH my-test
 
     # check missing parameters and start twice the same unit
     tests.systemd create-and-start-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"

--- a/tests/tests.systemd/task.yaml
+++ b/tests/tests.systemd/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the tests.systemd tool
 
+backends: [google]
+
 execute: |
     tests.systemd | MATCH 'usage: tests.systemd create-and-start-unit'
     tests.systemd -h | MATCH 'usage: tests.systemd create-and-start-unit'
@@ -28,7 +30,7 @@ execute: |
     tests.systemd stop-and-remove-unit my-test
 
     # check unit override
-    tests.systemd create-and-start-unit my-test "sleep 100" "[Unit]\nExecStart=sleep 5"
-    systemctl cat my-test | MATCH "^ExecStart=sleep 5$"
-    systemctl cat my-test | NOMATCH "^ExecStart=sleep 100$"
+    tests.systemd create-and-start-unit my-test "sleep 100" "[Service]\\nRestart=always\\nType=simple"
+    systemctl cat my-test | MATCH "^ExecStart=sleep 100$"
+    systemctl cat my-test | MATCH "^Restart=always$"
     tests.systemd stop-and-remove-unit my-test    

--- a/tests/tests.systemd/task.yaml
+++ b/tests/tests.systemd/task.yaml
@@ -1,0 +1,34 @@
+summary: smoke test for the tests.systemd tool
+
+execute: |
+    tests.systemd | MATCH 'usage: tests.systemd create-and-start-unit'
+    tests.systemd -h | MATCH 'usage: tests.systemd create-and-start-unit'
+    tests.systemd --help | MATCH 'usage: tests.systemd create-and-start-unit'
+
+    # check a simple unit
+    tests.systemd create-and-start-unit my-test "sleep 500"
+    systemctl is-active my-test
+    tests.systemd stop-and-remove-unit my-test
+    ! systemctl is-active my-test
+
+    # check the wait-for-service works when unit is inactive
+    tests.systemd create-and-start-unit my-test "sleep 5"
+    tests.systemd wait-for-service my-test active
+    tests.systemd wait-for-service my-test inactive
+    tests.systemd stop-and-remove-unit my-test
+    systemctl status my-test 2>&1 | MATCH "Unit my-test.service could not be found."
+
+    # check missing parameters and start twice the same unit
+    tests.systemd create-and-start-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd create-and-start-unit my-test  2>&1 | MATCH "tests.systemd: unit command line cannot be empty"
+    tests.systemd create-and-start-unit my-test "sleep 5"
+    tests.systemd create-and-start-unit my-test "sleep 5" 2>&1 | MATCH "tests.systemd: unit service file already exist"
+    tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd stop-and-remove-unit my-test
+
+    # check unit override
+    tests.systemd create-and-start-unit my-test "sleep 100" "[Unit]\nExecStart=sleep 5"
+    systemctl cat my-test | MATCH "^ExecStart=sleep 5$"
+    systemctl cat my-test | NOMATCH "^ExecStart=sleep 100$"
+    tests.systemd stop-and-remove-unit my-test    

--- a/tests/tests.systemd/task.yaml
+++ b/tests/tests.systemd/task.yaml
@@ -2,6 +2,11 @@ summary: smoke test for the tests.systemd tool
 
 backends: [google]
 
+systems: [-ubuntu-14.04-64]
+
+restore: |
+    tests.systemd stop-and-remove-unit my-test || true
+
 execute: |
     tests.systemd | MATCH 'usage: tests.systemd create-and-start-unit'
     tests.systemd -h | MATCH 'usage: tests.systemd create-and-start-unit'
@@ -30,7 +35,10 @@ execute: |
     tests.systemd stop-and-remove-unit my-test
 
     # check unit override
-    tests.systemd create-and-start-unit my-test "sleep 100" "[Service]\\nRestart=always\\nType=simple"
+    tests.systemd create-and-start-unit my-test "sleep 100" "[Unit]\nAfter=foo"
     systemctl cat my-test | MATCH "^ExecStart=sleep 100$"
-    systemctl cat my-test | MATCH "^Restart=always$"
-    tests.systemd stop-and-remove-unit my-test    
+    systemctl cat my-test | MATCH "^After=foo$"
+    tests.systemd stop-and-remove-unit my-test
+
+    # check a unit can be removed when it already was removed
+    tests.systemd stop-and-remove-unit my-test

--- a/tests/tests.systemd/task.yaml
+++ b/tests/tests.systemd/task.yaml
@@ -13,13 +13,13 @@ execute: |
     tests.systemd --help | MATCH 'usage: tests.systemd create-and-start-unit'
 
     # check a simple unit
-    tests.systemd create-and-start-unit my-test "sleep 500"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 500"
     systemctl is-active my-test
     tests.systemd stop-and-remove-unit my-test
-    ! systemctl is-active my-test
+    not systemctl is-active my-test
 
     # check the wait-for-service works when unit is inactive
-    tests.systemd create-and-start-unit my-test "sleep 5"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5"
     tests.systemd wait-for-service my-test active
     tests.systemd wait-for-service my-test inactive
     tests.systemd stop-and-remove-unit my-test
@@ -28,15 +28,15 @@ execute: |
     # check missing parameters and start twice the same unit
     tests.systemd create-and-start-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
     tests.systemd create-and-start-unit my-test  2>&1 | MATCH "tests.systemd: unit command line cannot be empty"
-    tests.systemd create-and-start-unit my-test "sleep 5"
-    tests.systemd create-and-start-unit my-test "sleep 5" 2>&1 | MATCH "tests.systemd: unit service file already exist"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5" 2>&1 | MATCH "tests.systemd: unit service file already exist"
     tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
     tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
     tests.systemd stop-and-remove-unit my-test
 
     # check unit override
-    tests.systemd create-and-start-unit my-test "sleep 100" "[Unit]\nAfter=foo"
-    systemctl cat my-test | MATCH "^ExecStart=sleep 100$"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 100" "[Unit]\nAfter=foo"
+    systemctl cat my-test | MATCH "^ExecStart=/bin/sleep 100$"
     systemctl cat my-test | MATCH "^After=foo$"
     tests.systemd stop-and-remove-unit my-test
 

--- a/tools/tests.systemd
+++ b/tools/tests.systemd
@@ -1,0 +1,114 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: tests.systemd create-and-start-unit <UNIT-NAME> <UNIT-COMMAND-LINE> <UNIT-OVERRIDE>"
+    echo "       tests.systemd stop-and-remove-unit <UNIT-NAME>"
+    echo "       tests.systemd wait-for-service <UNIT-NAME> <UNIT-STATE>"
+}
+
+# Create and start a persistent systemd unit that survives reboots. Use as:
+#   systemd_create_and_start_unit "name" "my-service --args"
+# The third arg supports "overrides" which allow to customize the service
+# as needed, e.g.:
+#   systemd_create_and_start_unit "name" "start" "[Unit]\nAfter=foo"
+create_and_start_unit() {
+    local name=$1
+    local start_line=$2
+    local override=$3
+
+    if [ -z "$name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+    if [ -z "$start_line" ]; then
+        echo "tests.systemd: unit command line cannot be empty"
+        return 1
+    fi
+    if [ -f "/etc/systemd/system/$name.service" ]; then
+        echo "tests.systemd: unit service file already exist"
+        return 1  
+    fi
+
+    printf '[Unit]\nDescription=Support for test %s\n[Service]\nType=simple\nExecStart=%s\n[Install]\nWantedBy=multi-user.target\n' "unknown" "$start_line" > "/etc/systemd/system/$name.service"
+    if [ -n "$override" ]; then
+        mkdir -p "/etc/systemd/system/$name.service.d"
+        # shellcheck disable=SC2059
+        printf "$override" >> "/etc/systemd/system/$name.service.d/override.conf"
+    fi
+
+    systemctl daemon-reload
+    systemctl enable "$name"
+    systemctl start "$name"
+    wait_for_service "$name"
+}
+
+stop_and_remove_unit() {
+    local name=$1
+
+    if [ -z "$name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+
+    systemctl stop "$name" || true
+    systemctl disable "$name" || true
+
+    rm -f "/etc/systemd/system/$name.service"
+    rm -rf "/etc/systemd/system/$name.service.d"
+    systemctl daemon-reload
+}
+
+wait_for_service() {
+    local service_name="$1"
+    local state="${2:-active}"
+
+    if [ -z "$name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+
+    for i in $(seq 300); do
+        if systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=$state"; then
+            return
+        fi
+        # show debug output every 1min
+        if [ "$i" -gt 0 ] && [ $(( i % 60 )) = 0 ]; then
+            systemctl status "$service_name" || true
+        fi
+        sleep 1
+    done
+
+    echo "tests.systemd: service $service_name did not become $state"
+    return 1
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit
+                ;;
+            *)
+                action=$(echo "$1" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "tests.systemd: no such command: $action" >&2
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tools/tests.systemd
+++ b/tools/tests.systemd
@@ -62,7 +62,7 @@ wait_for_service() {
     local service_name="$1"
     local state="${2:-active}"
 
-    if [ -z "$name" ]; then
+    if [ -z "$service_name" ]; then
         echo "tests.systemd: unit name cannot be empty"
         return 1
     fi


### PR DESCRIPTION
This change provides:
 . New basic tool to manage systemd services (systemd.sh helper)
 . New remote.wait-for tool 
 . New remote.retry tool 
 . New remote.refresh tool 

This change also include tests for the tools and a new nested testing mechanism for the new remote tools