### PR TITLE
Make tools work when are not in the spread env

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script is used to setup the path and other environemnt variables needed
+# This script is used to setup the path and other environment variables needed
 # to run the tools when the tools aren't used as part of a spread test.
 # The steps are:
 # 1. source the file: `. <PATH_TO_PROJECT>/setup.sh`

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This script is used to setup the path and other environemnt variables needed
+# to run the tools when the tools aren't used as part of a spread test.
+# The steps are:
+# 1. source the file: `. <PATH_TO_PROJECT>/setup.sh`
+# 2. run any tool: `retry true`
+
 PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 export PATH=$PATH:$PROJECT_DIR/tools:$PROJECT_DIR/utils:$PROJECT_DIR/remote

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+export PATH=$PATH:$PROJECT_DIR/tools:$PROJECT_DIR/utils:$PROJECT_DIR/remote

--- a/tools/os.paths
+++ b/tools/os.paths
@@ -7,42 +7,27 @@ show_help() {
 }
 
 snap_mount_dir() {
-    local SNAP_MOUNT_DIR=/snap
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|arch-*)
-            SNAP_MOUNT_DIR=/var/lib/snapd/snap
-            ;;
-        *)
-            ;;
-    esac
-    echo "$SNAP_MOUNT_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-arch-linux; then
+        echo "/var/lib/snapd/snap"
+    else
+        echo "/snap"
+    fi
 }
 
 media_dir() {
-    local MEDIA_DIR=/media
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|arch-*|opensuse-*)
-            MEDIA_DIR=/run/media
-            ;;
-        *)
-            ;;
-    esac
-    echo "$MEDIA_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-arch-linux || os.query is-opensuse; then
+        echo "/run/media"
+    else
+        echo "/media"
+    fi
 }
 
 libexec_dir() {
-    local LIBEXEC_DIR=/usr/lib
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|opensuse-tumbleweed-*)
-            LIBEXEC_DIR=/usr/libexec
-            ;;
-        *)
-            ;;
-    esac
-    echo "$LIBEXEC_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-opensuse tumbleweed; then
+        echo "/usr/libexec"
+    else
+        echo "/usr/lib"
+    fi
 }
 
 main() {

--- a/tools/os.query
+++ b/tools/os.query
@@ -11,23 +11,53 @@ show_help() {
 }
 
 is_core() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release
+    fi
 }
 
 is_core16() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="16"' /etc/os-release
+    fi
 }
 
 is_core18() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="18"' /etc/os-release
+    fi
 }
 
 is_core20() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="20"' /etc/os-release
+    fi
 }
 
 is_core22() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="22"' /etc/os-release
+    fi
 }
 
 is_classic() {
@@ -68,7 +98,11 @@ is_debian() {
     if [ -z "$VERSION" ]; then
         grep -qFx 'ID=debian' /etc/os-release
     elif [ "$VERSION" == "sid" ]; then
-        [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+        if [ -n "$SPREAD_SYSTEM" ]; then
+            [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+        else
+            grep -qFx 'ID=debian' /etc/os-release && grep -qE '^PRETTY_NAME=.*/sid"$' /etc/os-release
+        fi
     else
         grep -qFx 'ID=debian' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
     fi
@@ -79,7 +113,11 @@ is_fedora() {
     if [ -z "$VERSION" ]; then
         grep -qFx 'ID=fedora' /etc/os-release
     elif [ "$VERSION" == "rawhide" ]; then
-        [[ "$SPREAD_SYSTEM" == fedora-rawhide-* ]]
+        if [ -n "$SPREAD_SYSTEM" ]; then
+            [[ "$SPREAD_SYSTEM" == fedora-rawhide-* ]]
+        else
+            grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide" /etc/os-release
+        fi
     else
         grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "VERSION_ID=$VERSION" /etc/os-release
     fi

--- a/tools/tests.pkgs
+++ b/tools/tests.pkgs
@@ -82,7 +82,7 @@ import_backend() {
         # source is not found failing with SC1090 and SC1091
         #shellcheck disable=SC1090,SC1091
         . "$TOOLS_DIR/tests.pkgs.zypper.sh"
-    elif os.query is-arch-linux)
+    elif os.query is-arch-linux; then
         # Disabled because when the project is imported as a submodule the
         # source is not found failing with SC1090 and SC1091
         #shellcheck disable=SC1090,SC1091

--- a/tools/tests.pkgs
+++ b/tools/tests.pkgs
@@ -64,40 +64,33 @@ import_backend() {
         TOOLS_DIR="$TESTSTOOLS"
     fi
     
-    case "$1" in
-        ubuntu-core-*)
-            echo "tests.pkgs: Ubuntu Core is not supported" >&2
-            exit 1
-            ;;
-        ubuntu-*|debian-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.apt.sh"
-            ;;
-        fedora-*|centos-*|redhat-*|amazon-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.dnf-yum.sh"
-            ;;
-        opensuse-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.zypper.sh"
-            ;;
-        arch-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.pacman.sh"
-            ;;
-        *)
-            echo "tests.pkgs: cannot import packaging backend $1" >&2
-            exit 1
-            ;;
-    esac
+    if os.query is-core; then
+        echo "tests.pkgs: Ubuntu Core is not supported" >&2
+        return 1
+    elif os.query is-ubuntu || os.query is-debian; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.apt.sh"
+    elif os.query is-fedora || os.query is-centos || os.query is-amazon-linux; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.dnf-yum.sh"
+    elif os.query is-opensuse; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.zypper.sh"
+    elif os.query is-arch-linux)
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.pacman.sh"
+    else
+        echo "tests.pkgs: cannot import packaging backend $1" >&2
+        return 1
+    fi
 }
 
 main() {
@@ -106,11 +99,7 @@ main() {
         exit 1
     fi
 
-    if [ -z "${SPREAD_SYSTEM:-}" ]; then
-        echo "tests.pkg: cannot manage packages without knowing SPREAD_SYSTEM" >&2
-        exit 1
-    fi
-    import_backend "$SPREAD_SYSTEM"
+    import_backend
 
     action=
     while [ $# -gt 0 ]; do


### PR DESCRIPTION
This is to be able to use the project in other contexts like testflinger
scripts without hte spread environment.

Also it includes a setup script that when it is sourced, it adds the
tools to the path.