### PR TITLE
Set ServerAliveInterval to remote.exec

### DIFF
--- a/remote/remote.exec
+++ b/remote/remote.exec
@@ -78,7 +78,7 @@ remote_exec() {
     SSH_CERT="$(_get_cert)"
 
     # shellcheck disable=SC2153,SC2086
-    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ConnectTimeout="$timeout" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
+    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ServerAliveInterval=10 -o ConnectTimeout="$timeout" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
 }
 
 main() {    


### PR DESCRIPTION
The -o ServerAliveInterval=10 should fix some ssh hangs when ssh restarts