### PR TITLE
New comparisons for ubuntu versions

### DIFF
--- a/tests/os.query/task.yaml
+++ b/tests/os.query/task.yaml
@@ -37,6 +37,20 @@ execute: |
             ! os.query is-ubuntu 14.04
             ! os.query is-core
             os.query is-pc-amd64
+
+            # check ubuntu comparisons
+            os.query is-ubuntu-ge 14.04
+            os.query is-ubuntu-ge 18.04
+            ! os.query is-ubuntu-ge 20.04
+            os.query is-ubuntu-gt 16.04
+            ! os.query is-ubuntu-gt 18.04
+            os.query is-ubuntu-le 18.04
+            os.query is-ubuntu-le 20.04
+            ! os.query is-ubuntu-le 16.04
+            os.query is-ubuntu-lt 20.04
+            ! os.query is-ubuntu-lt 18.04
+            os.query is-ubuntu-lt 2>&1 | MATCH "os.query: version id is expected"
+            os.query is-ubuntu-lt 20.04-64 2>&1 | MATCH 'os.query: invalid version format "20.04-64" provided'
             ;;
         ubuntu-20.04-64)
             os.query is-focal
@@ -67,6 +81,11 @@ execute: |
             os.query is-debian 10
             os.query is-classic
             ! os.query is-core
+
+            # check ubuntu comparisons
+            ! os.query is-ubuntu-lt 20.04
+            os.query is-ubuntu-ge 20.04 | MATCH "os.query: comparing non ubuntu system"
+            os.query is-ubuntu-lt 2>&1 | MATCH "os.query: version id is expected"
             ;;
         debian-11-64)
             os.query is-debian

--- a/tools/os.query
+++ b/tools/os.query
@@ -2,9 +2,10 @@
 
 show_help() {
     echo "usage: os.query is-core, is-classic"
-    echo "       os.query is-core16, is-core18, is-core20, is-core22"
+    echo "       os.query is-core16, is-core18, is-core20, is-core22, is-core24"
     echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy"
     echo "       os.query is-ubuntu [ID], is-debian [ID], is-fedora [ID], is-amazon-linux, is-arch-linux, is-centos [ID], is-opensuse [ID]"
+    echo "       os.query is-ubuntu-gt [ID], is-ubuntu-ge [ID], is-ubuntu-lt [ID], is-ubuntu-le [ID]"
     echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64, is-s390x"
     echo ""
     echo "Get general information about the current system"
@@ -60,6 +61,16 @@ is_core22() {
     fi
 }
 
+is_core24() {
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-24-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
+    fi
+}
+
 is_classic() {
     ! is_core
 }
@@ -92,6 +103,54 @@ is_ubuntu() {
         grep -qFx 'ID=ubuntu' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
     fi
 }
+
+is_ubuntu_gt() {
+    compare_ubuntu "${1:-}" "-gt"
+}
+
+is_ubuntu_ge() {
+    compare_ubuntu "${1:-}" "-ge"
+}
+
+is_ubuntu_lt() {
+    compare_ubuntu "${1:-}" "-lt"
+}
+
+is_ubuntu_le() {
+    compare_ubuntu "${1:-}" "-le"
+}
+
+compare_ubuntu() {
+    VERSION=$1
+    OPERAND=$2
+
+    if [ -z "$VERSION" ]; then
+        echo "os.query: version id is expected"
+        exit 1
+    fi
+
+    if ! grep -qFx 'ID=ubuntu' /etc/os-release; then
+        echo "os.query: comparing non ubuntu system"
+        return 1
+    fi
+
+    NUM_RE='^[0-9]+$'
+    NUM_VERSION="$(echo $VERSION | tr -d '".')"
+    if ! [[ $NUM_VERSION =~ $NUM_RE ]] ; then
+       echo "os.query: invalid version format \"$VERSION\" provided"
+       exit 1
+    fi
+
+    SYS_VERSION="$(grep 'VERSION_ID' /etc/os-release)"
+    SYS_VERSION="$(echo ${SYS_VERSION#*=} | tr -d '".')"
+    if ! [[ $SYS_VERSION =~ $NUM_RE ]] ; then
+       echo "os.query: invalid version format \"$SYS_VERSION\" retrieved from system"
+       exit 1
+    fi
+
+    test "$SYS_VERSION" "$OPERAND" "$NUM_VERSION"
+}
+
 
 is_debian() {
     VERSION=$1


### PR DESCRIPTION
The change introduces new comparisons for ubuntu systems. Also is introduced the new check to validate uc24

The new commands supported are:
os.query is-ubuntu-gt [ID]
         is-ubuntu-ge [ID]
         is-ubuntu-lt [ID]
         is-ubuntu-le [ID]

The tests have been updated accordingly