### PR TITLE
Update check-test-format to support a dir and a list of files

### DIFF
--- a/tests/check-test-format/task.yaml
+++ b/tests/check-test-format/task.yaml
@@ -13,33 +13,30 @@ restore: |
 execute: |
     check-test-format -h | MATCH "usage: check-test-format"
 
-    # Check the format of the spread tests in this project
-    check-test-format "$PROJECT_PATH/tests"
+    # Check failing tasks with order not desired
+    check-test-format --tests "$PWD/tasks/task1.yaml" 2>&1 | MATCH "Keys 'execute' and 'prepare' do not follow the desired order"
 
-    # Check failing tasks
-    cp "$PWD/tasks/task1" "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Keys 'execute' and 'prepare' do not follow the desired order"
-    rm "$PWD/tasks/task.yaml"
+    check-test-format --tests "$PWD/tasks/task2.yaml" 2>&1 | MATCH "Keys 'execute' and 'restore' do not follow the desired order"
 
-    cp "$PWD/tasks/task2" "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Keys 'execute' and 'restore' do not follow the desired order"
-    rm "$PWD/tasks/task.yaml"
+    check-test-format --tests "$PWD/tasks/task3.yaml" 2>&1 | MATCH "Keys 'systems' and 'backends' do not follow the desired order"
+    check-test-format --tests "$PWD/tasks/task3.yaml" 2>&1 | MATCH "Key 'execute' is mandatory"
 
-    cp "$PWD/tasks/task3" "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Keys 'systems' and 'backends' do not follow the desired order"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Key 'execute' is mandatory"
-    rm "$PWD/tasks/task.yaml"
+    # Check passing a file with more than 1 error
+    check-test-format --tests "$PWD/tasks/task4.yaml" 2>&1 | MATCH "Keys 'environment' and 'systems' do not follow the desired order"
+    check-test-format --tests "$PWD/tasks/task4.yaml" 2>&1 | MATCH "Key 'details' is mandatory"
 
-    cp "$PWD/tasks/task4" "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Keys 'environment' and 'systems' do not follow the desired order"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Key 'execute' is mandatory"
-    rm "$PWD/tasks/task.yaml"
+    # Check passing a file with a non supported section
+    check-test-format --tests "$PWD/tasks/task5.yaml" 2>&1 | MATCH "key 'unsupported' is not among the supported keys"
 
-    cp "$PWD/tasks/task5" "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "key 'unsupported' is not among the supported keys"
-    rm "$PWD/tasks/task.yaml"
+    # Check passing more than 1 file to the tool
+    check-test-format --tests "$PWD/tasks/task4.yaml" "$PWD/tasks/task5.yaml" 2>&1 | MATCH "Key 'details' is mandatory"
+    check-test-format --tests "$PWD/tasks/task4.yaml" "$PWD/tasks/task5.yaml" 2>&1 | MATCH "key 'unsupported' is not among the supported keys"
 
-    cp "$PWD/tasks/task6" "$PWD/tasks/task.yaml"
+    # Check passing a file with a non supported format
+    # Check passing a dir
+    cp "$PWD/tasks/task6.yaml" "$PWD/tasks/task.yaml"
     echo "newtext" >> "$PWD/tasks/task.yaml"
-    check-test-format "$PWD/tasks" 2>&1 | MATCH "Invalid task format, checks failed for task"
+    check-test-format --tests "$PWD/tasks/task.yaml" 2>&1 | MATCH "Invalid task format, checks failed for task"
+    check-test-format --dir "$PWD/tasks/" 2>&1 | MATCH "Invalid task format, checks failed for task"
+    check-test-format --dir "$PWD/tasks/" 2>&1 | NOMATCH "Key 'execute' is mandatory"
     rm "$PWD/tasks/task.yaml"

--- a/tests/check-test-format/tasks/task1
+++ b/tests/check-test-format/tasks/task1
@@ -1,7 +1,0 @@
-summary: this is the summary
-
-execute: |
-    echo "execute"
-
-prepare: |
-    echo "prepare"

--- a/tests/check-test-format/tasks/task1.yaml
+++ b/tests/check-test-format/tasks/task1.yaml
@@ -1,4 +1,9 @@
 summary: this is the summary
 
+details: details
+
 execute: |
     echo "execute"
+
+prepare: |
+    echo "prepare"

--- a/tests/check-test-format/tasks/task2.yaml
+++ b/tests/check-test-format/tasks/task2.yaml
@@ -1,5 +1,7 @@
 summary: this is the summary
 
+details: details
+
 execute: |
     echo "execute"
 

--- a/tests/check-test-format/tasks/task3.yaml
+++ b/tests/check-test-format/tasks/task3.yaml
@@ -1,10 +1,7 @@
 summary: this is the summary
 
-details: no details
-
-environment:
-    TEST: 1
+details: details
 
 systems: [ ubuntu-20.04-64 ]
 
-
+backends: [ google ]

--- a/tests/check-test-format/tasks/task4.yaml
+++ b/tests/check-test-format/tasks/task4.yaml
@@ -1,5 +1,8 @@
 summary: this is the summary
 
+environment:
+    TEST: 1
+
 systems: [ ubuntu-20.04-64 ]
 
-backends: [ google ]
+

--- a/tests/check-test-format/tasks/task5.yaml
+++ b/tests/check-test-format/tasks/task5.yaml
@@ -1,0 +1,10 @@
+summary: this is the summary
+
+details: details
+
+unsupported: not supported
+
+systems: [ ubuntu-20.04-64 ]
+
+execute: |
+    echo "execute"

--- a/tests/check-test-format/tasks/task6.yaml
+++ b/tests/check-test-format/tasks/task6.yaml
@@ -1,8 +1,6 @@
 summary: this is the summary
 
-unsupported: not supported
-
-systems: [ ubuntu-20.04-64 ]
+details: details
 
 execute: |
     echo "execute"

--- a/utils/check-test-format
+++ b/utils/check-test-format
@@ -28,7 +28,7 @@ SUPPORTED_KEYS = [
     "debug",
     "execute",
 ]
-MANDATORY_KEYS = ["summary", "execute"]
+MANDATORY_KEYS = ["summary", "details", "execute"]
 
 
 def check_mandatory_keys(task_keys):
@@ -92,7 +92,6 @@ def check_task_format(filepath):
 
     return True
 
-
 def check_dir(directory):
     if not os.path.isdir(directory):
         print("Format checks failed for directory {}".format(directory))
@@ -106,11 +105,27 @@ def check_dir(directory):
 
     return status
 
+def check_tests(tests):
+    status = True
+    for test in tests:
+        if not os.path.isfile(test):
+            print("Format checks failed for test {}".format(test))
+            print(" - The path is not a file")
+            status = False
+            continue
+
+        if not check_task_format(test):
+            status = False
+
+    return status
 
 def _make_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "directory", help="path to the directory to check recursively"
+        "--dir", help="path to the directory to check recursively"
+    )
+    parser.add_argument(
+        "--tests", help="list of tests path to check", nargs='+'
     )
     return parser
 
@@ -119,8 +134,16 @@ def main():
     parser = _make_parser()
     args = parser.parse_args()
 
-    sys.exit(not check_dir(args.directory))
+    status = True
+    if args.tests:
+        if not check_tests(args.tests):
+            status = False
 
+    if args.dir:
+        if not check_dir(args.dir):
+            status = False
+
+    sys.exit(status)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is needed to allow to check just the changed files in snapd.

This is breaking the backward compatibility, so to migrate it is needed to pass --dir <DIR> now