### PR TITLE
tools: fix support for multi-arch packages on apt-based systems

### DIFF
--- a/tests/tests.pkgs/task.yaml
+++ b/tests/tests.pkgs/task.yaml
@@ -51,3 +51,10 @@ execute: |
     tests.pkgs noexist test-snapd-pkg-1 2>&1 | MATCH 'tests.pkgs: unknown command noexist'
     tests.pkgs -install test-snapd-pkg-1 2>&1 | MATCH 'tests.pkgs: unknown option -install'
 
+    # Install the test pkg and check it is installed and query it
+    if test -n "$(command -v apt)"; then
+      dpkg --add-architecture i386
+      tests.pkgs install libc6:i386
+      tests.pkgs is-installed libc6:386
+      tests.pkgs remove libc6:i386
+    fi

--- a/tests/tests.pkgs/task.yaml
+++ b/tests/tests.pkgs/task.yaml
@@ -52,9 +52,10 @@ execute: |
     tests.pkgs -install test-snapd-pkg-1 2>&1 | MATCH 'tests.pkgs: unknown option -install'
 
     # Install the test pkg and check it is installed and query it
-    if test -n "$(command -v apt)"; then
+    # run this just on amd64 architecture and skip trusty
+    if ( os.query is-debian || os.query is-ubuntu-ge 1604 ) && os.query is-pc-amd64 ; then
       dpkg --add-architecture i386
-      tests.pkgs install libc6:i386
-      tests.pkgs is-installed libc6:386
-      tests.pkgs remove libc6:i386
+      tests.pkgs install test-snapd-pkg-3
+      tests.pkgs is-installed test-snapd-pkg-3
+      tests.pkgs remove test-snapd-pkg-3
     fi

--- a/tools/tests.pkgs
+++ b/tools/tests.pkgs
@@ -151,7 +151,8 @@ main() {
             cmd_list_installed
             ;;
         remove)
-            cmd_remove "$(remap_many "$@")"
+            # shellcheck disable=SC2046
+            cmd_remove $(remap_many "$@")
             ;;
         *)
             echo "tests.pkgs: unknown action $action" >&2

--- a/tools/tests.pkgs.apt.sh
+++ b/tools/tests.pkgs.apt.sh
@@ -60,5 +60,8 @@ cmd_list_installed() {
 }
 
 cmd_remove() {
-    apt-get remove --yes "$@"
+    # Allow removing essential packages, that may get installed when using i386
+    # packages on amd64 system. Normally they would be really essential but in
+    # this case they are not really as essential.
+    apt-get remove --yes --allow-remove-essential "$@"
 }

--- a/tools/tests.pkgs.apt.sh
+++ b/tools/tests.pkgs.apt.sh
@@ -56,7 +56,7 @@ cmd_query() {
 }
 
 cmd_list_installed() {
-    apt list --installed | cut -d/ -f1 | sort
+    apt list --installed | cut -d ' ' -f 1,3 | sed -e 's@/.*\s@:@g' | sort
 }
 
 cmd_remove() {

--- a/tools/tests.pkgs.apt.sh
+++ b/tools/tests.pkgs.apt.sh
@@ -43,8 +43,8 @@ cmd_install() {
                 ;;
         esac
     done
-    # shellcheck disable=SC2068,SC2086
-    apt-get install $APT_FLAGS $@
+    # shellcheck disable=SC2086
+    apt-get install $APT_FLAGS "$@"
 }
 
 cmd_is_installed() {
@@ -60,6 +60,5 @@ cmd_list_installed() {
 }
 
 cmd_remove() {
-    # shellcheck disable=SC2068
-    apt-get remove --yes $@
+    apt-get remove --yes "$@"
 }

--- a/tools/tests.pkgs.apt.sh
+++ b/tools/tests.pkgs.apt.sh
@@ -22,6 +22,15 @@ remap_one() {
         test-snapd-pkg-2)
             echo "robotfindskitten"
             ;;
+        test-snapd-pkg-3)
+            if os.query is-debian || os.query is-trusty; then
+                echo cpp:i386
+            elif os.query is-xenial || os.query is-bionic; then
+                echo cpp-5:i386
+            else
+                echo cpp-9:i386
+            fi
+            ;;
         *)
             echo "$1"
             ;;
@@ -48,7 +57,7 @@ cmd_install() {
 }
 
 cmd_is_installed() {
-    dpkg -S "$1" >/dev/null 2>&1
+    dpkg -l "$1" | grep -E "ii +$1" >/dev/null 2>&1
 }
 
 cmd_query() {
@@ -63,5 +72,10 @@ cmd_remove() {
     # Allow removing essential packages, that may get installed when using i386
     # packages on amd64 system. Normally they would be really essential but in
     # this case they are not really as essential.
-    apt-get remove --yes --allow-remove-essential "$@"
+    local REMOVE_FLAGS="--allow-remove-essential"
+    if os.query is-trusty; then
+        REMOVE_FLAGS=""
+    fi
+    # shellcheck disable=SC2086
+    apt-get remove --yes $REMOVE_FLAGS "$@"
 }


### PR DESCRIPTION
The root of the problem is that package listing logic had previously discarded package architecture, and a single system may have the same package name and version installed but for two different architectures. This is most common with the various library packages.

There are three patches in total, the first one fixes quoting around arguments. The second changes the format of the internal package list from `foo` to `foo:arch`. The last one allows removing essential packages which is required to completely remove the side effect of installing a single `:i386` package on an amd64 system.