### PR TITLE
tools: add os.query is-core26

### DIFF
--- a/tools/os.query
+++ b/tools/os.query
@@ -2,7 +2,7 @@
 
 show_help() {
     echo "usage: os.query is-core, is-classic"
-    echo "       os.query is-core16, is-core18, is-core20, is-core22, is-core24"
+    echo "       os.query is-core16, is-core18, is-core20, is-core22, is-core24, is-core26"
     echo "       os.query is-core-gt, is-core-ge, is-core-lt, is-core-le"
     echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy, is-noble"
     echo "       os.query is-ubuntu [ID], is-debian [ID], is-fedora [ID], is-amazon-linux [ID], is-arch-linux, is-centos [ID], is-opensuse [ID]"
@@ -34,6 +34,10 @@ is_core22() {
 
 is_core24() {
     grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
+}
+
+is_core26() {
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="26"' /etc/os-release
 }
 
 is_core_gt() {


### PR DESCRIPTION
This was added to the snapd vendored version of these tools in https://github.com/canonical/snapd/commit/96384186fa2053e361b802d7f93ed3434b4d1748