### PR TITLE
use echo -e instead of echo in is-kernel comparisons

### DIFF
--- a/tools/os.query
+++ b/tools/os.query
@@ -312,7 +312,7 @@ compare_kernel() {
             ;;
     esac
 
-    echo "$TO_SORT" | sort -CV
+    echo -e "$TO_SORT" | sort -CV
 }
 
 main() {


### PR DESCRIPTION
Without the `-e` option, `echo` treats `\n` as a string
```
$ echo 'a\nb'
a\nb
```
this changes from using `echo` to `echo -e`
```
$ echo -e 'a\nb'
a
b
```