### PR TITLE
remote: prevent wait-for from incorrectly succeeding after exceeding retries

### DIFF
--- a/remote/remote.wait-for
+++ b/remote/remote.wait-for
@@ -123,7 +123,7 @@ wait_for_reboot() {
     done
 
     echo ""
-    if [ "$last_boot_id" != "$initial_boot_id" ]; then
+    if [[ "$last_boot_id" =~ .*-.*-.*-.*-.* ]] && [ "$last_boot_id" != "$initial_boot_id" ]; then
         echo "remote.wait-for: reboot completed"
     else
         echo "remote.wait-for: boot id did not change"


### PR DESCRIPTION
Prevent wait-for from incorrectly succeeding after exceeding retries.

This issue was detected while investigating failing nested test e.g. tests/nested/manual/broken-model:

```
  for (( i=0 ; i < 100 ; i++ )); do
    if [ "${sent_recovery}" -lt "$(tests.nested get serial-log | grep -c "Enter recovery key for")" ]; then
      sent_recovery=$((sent_recovery+1))
      echo "${recovery_key}" | nc -q 0 127.0.0.1 7777
      break
    fi
    sleep 10
  done

  test "${sent_recovery}" -gt 0

  remote.wait-for reboot "$boot_id"          <----- this incorrectly continues after retries exceeded
```

In the background the  recovery key is not accepted, so the machine starts rebooting in a loop.
in this situation this problem hides the fact that the recovery key is not accepted.