### PR TITLE
remote: fix wait-for spelling issues (number 2)

### DIFF
--- a/remote/remote.wait-for
+++ b/remote/remote.wait-for
@@ -42,7 +42,7 @@ wait_for_ssh() {
         sleep "$wait"
     done
     echo ""
-    echo "remote.wait-for: ssh connection stablished"
+    echo "remote.wait-for: ssh connection established"
 }
 
 wait_for_no_ssh() {
@@ -91,7 +91,7 @@ get_boot_id() {
 }
 
 wait_for_reconnect_ssh() {
-    echo "remote.wait-for: waiting for ssh is recoonected"
+    echo "remote.wait-for: waiting for ssh to be reconnected"
     wait_for_no_ssh "$DEFAULT_WAIT_FOR_NO_SSH_ATTEMPTS" "$DEFAULT_WAIT_FOR_NO_SSH_WAIT"
     wait_for_ssh "$DEFAULT_WAIT_FOR_SSH_ATTEMPTS" "$DEFAULT_WAIT_FOR_SSH_WAIT"
 }


### PR DESCRIPTION
Fix spelling issues.

Follow up on https://github.com/canonical/snapd-testing-tools/pull/71