### PR TITLE
tools/os.paths: update for opensuse alternative snap mount location

### DIFF
--- a/tools/os.paths
+++ b/tools/os.paths
@@ -9,6 +9,8 @@ show_help() {
 snap_mount_dir() {
     if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-arch-linux; then
         echo "/var/lib/snapd/snap"
+    elif os.query is-opensuse && [ -d /var/lib/snapd/snap ]; then
+        echo "/var/lib/snapd/snap"
     else
         echo "/snap"
     fi


### PR DESCRIPTION
openSUSE packaging may alternatively use /var/lib/snapd/snap.