### PR TITLE
tools: stabilize rpm package tracking in fedora/opensuse spread cleanup

### DIFF
--- a/tools/tests.pkgs.dnf-yum.sh
+++ b/tools/tests.pkgs.dnf-yum.sh
@@ -65,7 +65,9 @@ cmd_query() {
 }
 
 cmd_list_installed() {
-    rpm -qa | sort
+    # Keep only the stable package identity (name.arch), excluding version data,
+    # so restore diffs do not treat package upgrades during a test as new installs.
+    rpm -qa --qf '%{NAME}.%{ARCH}\n' | sort -u
 }
 
 cmd_remove() {

--- a/tools/tests.pkgs.zypper.sh
+++ b/tools/tests.pkgs.zypper.sh
@@ -57,7 +57,9 @@ cmd_query() {
 }
 
 cmd_list_installed() {
-    rpm -qa | sort
+    # Keep only the stable package identity (name.arch), excluding version data,
+    # so restore diffs do not treat package upgrades during a test as new installs.
+    rpm -qa --qf '%{NAME}.%{ARCH}\n' | sort -u
 }
 
 cmd_remove() {


### PR DESCRIPTION
This corresponds to an equivalent PR in snapd: https://github.com/canonical/snapd/pull/17136