### PR TITLE
allow spread filter to have more specific rules than tasks

### DIFF
--- a/tests/spread-filter/task.yaml
+++ b/tests/spread-filter/task.yaml
@@ -120,3 +120,10 @@ execute: |
     # Scenario: When naming a task folder, any change to a task in a different folder will not cause it to run
     spread-filter -r rules.yaml -p google:ubuntu -c tests/nested/test1/task.yaml -t tests/nested/core/ > res
     test "$(wc -w < res)" -eq 0
+
+    # Scenario: When only a golang test is changed, then the unit testing suites should run
+    spread-filter -r rules.yaml -p google:ubuntu -c asserts/sample_test.go -t tests/ > res
+    test "$(wc -w < res)" -eq 3
+    MATCH "google:ubuntu:tests/unit/c-unit-tests-clang" < res
+    MATCH "google:ubuntu:tests/unit/c-unit-tests-gcc" < res
+    MATCH "google:ubuntu:tests/unit/go" < res

--- a/utils/spread-filter
+++ b/utils/spread-filter
@@ -185,6 +185,8 @@ class ExecutionManager:
                         for task in tasks:
                             if task.startswith(dir):
                                 all_executions.append(task)
+                            elif dir.startswith(task):
+                                all_executions.append(dir)
                     else:
                         all_executions.append(dir)
 


### PR DESCRIPTION
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/main.yaml -c 'a_test.go' -p  "openstack:ubuntu-24.04-64" -t 'tests/...'
openstack:ubuntu-24.04-64:tests/unit/c-unit-tests-clang openstack:ubuntu-24.04-64:tests/unit/c-unit-tests-gcc openstack:ubuntu-24.04-64:tests/unit/go
```

```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/main.yaml -c 'a_test.go' -p  "openstack:ubuntu-24.04-64" -t 'tests/main/ack'

$
```

```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/main.yaml -c 'a.go' -p  "openstack:ubuntu-24.04-64" -t 'tests/main/ack'
openstack:ubuntu-24.04-64:tests/main/ack
```

```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/main.yaml -c 'a.go' -p  "openstack:ubuntu-24.04-64" -t 'tests/...'
openstack:ubuntu-24.04-64:tests/
```